### PR TITLE
fix: modules uses the wrong path, close #33

### DIFF
--- a/src/webpack/loaders/load.ts
+++ b/src/webpack/loaders/load.ts
@@ -1,5 +1,6 @@
 import type { LoaderContext } from 'webpack'
 import { UnpluginContext } from '../../types'
+import { slash } from '../utils'
 
 export default async function load (this: LoaderContext<any>, source: string, map: any) {
   const callback = this.async()
@@ -20,7 +21,7 @@ export default async function load (this: LoaderContext<any>, source: string, ma
     id = id.slice(plugin.__virtualModulePrefix.length)
   }
 
-  const res = await plugin.load.call(context, id)
+  const res = await plugin.load.call(context, slash(id))
 
   if (res == null) {
     callback(null, source, map)

--- a/src/webpack/utils.ts
+++ b/src/webpack/utils.ts
@@ -1,0 +1,7 @@
+export function slash (path: string) {
+  return path.replace(/\\/g, '/')
+}
+
+export function backSlash (path: string) {
+  return path.replace(/\//g, '\\')
+}


### PR DESCRIPTION
An error occurred when using webpack to build unplugin-icons [#33 ]