### PR TITLE
fix: webpack hook tapPromise must return Promise object

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -155,8 +155,8 @@ export function getWebpackPlugin<UserOptions = {}> (
         plugin.buildStart?.()
 
         if (plugin.buildEnd) {
-          compiler.hooks.done.tapPromise(plugin.name, () => {
-            plugin.buildEnd!()
+          compiler.hooks.done.tapPromise(plugin.name, async () => {
+            await plugin.buildEnd!()
           })
         }
       }


### PR DESCRIPTION
This PR just make the function in tapPromise be async, so that they can return promise properly.
see #41 