### PR TITLE
feat: support esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently supports:
 - [Vite](https://vitejs.dev/)
 - [Rollup](https://rollupjs.org/)
 - [Webpack](https://webpack.js.org/)
+- [esbuild](https://esbuild.github.io/)
 
 ## Hooks
 
@@ -53,6 +54,7 @@ export const unplugin = createUnplugin((options: UserOptions) => {
 export const vitePlugin = unplugin.vite
 export const rollupPlugin = unplugin.rollup
 export const webpackPlugin = unplugin.webpack
+export const esbuildPlugin = unplugin.esbuild
 ```
 
 ### Plugin Installation
@@ -94,6 +96,19 @@ module.exports = {
 }
 ```
 
+###### esbuild
+
+```ts
+// esbuild.config.js
+import { build } from 'esbuild'
+
+build({
+  plugins: [
+    require('./my-unplugin').esbuild({ /* options */ })
+  ]
+})
+```
+
 ### Framework-specific Logic
 
 While `unplugin` provides compatible layers for some hooks, the functionality of it is limited to the common subset of the build's plugins capability. For more advanced framework-specific usages, `unplugin` provides an escape hatch for that.
@@ -101,7 +116,7 @@ While `unplugin` provides compatible layers for some hooks, the functionality of
 ```ts
 export const unplugin = createUnplugin((options: UserOptions, meta) => {
 
-  console.log(meta.framework) // 'vite' | 'rollup' | 'webpack'
+  console.log(meta.framework) // 'vite' | 'rollup' | 'webpack' | 'esbuild'
 
   return {
     // common unplugin hooks
@@ -121,6 +136,13 @@ export const unplugin = createUnplugin((options: UserOptions, meta) => {
     },
     webpack(compiler) {
       // configure Webpack compiler
+    },
+    esbuild: {
+      // change the filter of onResolve and onLoad
+      onResolveFilter?: RegExp
+      onLoadFilter?: RegExp
+      // or you can completely replace the setup logic
+      setup?: EsbuildPlugin['setup']
     }
   }
 })

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently supports:
 
 ###### Supported
 
-| Hook | Rollup | Vite | Webpack 4 | Webpack 5 | Esbuild |
+| Hook | Rollup | Vite | Webpack 4 | Webpack 5 | esbuild |
 | ---- | :----: | :--: | :-------: | :-------: | :-----: |
 | [`buildStart`](https://rollupjs.org/guide/en/#buildstart) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [`buildEnd`](https://rollupjs.org/guide/en/#buildend) | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -15,18 +15,19 @@ Currently supports:
 
 ###### Supported
 
-| Hook | Rollup | Vite | Webpack 4 | Webpack 5 |
-| ---- | :----: | :--: | :-------: | :-------: |
-| [`buildStart`](https://rollupjs.org/guide/en/#buildstart) | ✅ | ✅ | ✅ | ✅ |
-| [`buildEnd`](https://rollupjs.org/guide/en/#buildend) | ✅ | ✅ | ✅ | ✅ |
-| `transformInclude`* | ✅ | ✅ | ✅ | ✅ |
-| [`transform`](https://rollupjs.org/guide/en/#transformers) | ✅ | ✅ | ✅ | ✅ |
-| [`enforce`](https://rollupjs.org/guide/en/#enforce) | ❌\*\* | ✅ | ✅ | ✅ |
-| [`resolveId`](https://rollupjs.org/guide/en/#resolveid) | ✅ | ✅ | ✅ | ✅ |
-| [`load`](https://rollupjs.org/guide/en/#load) | ✅ | ✅ | ✅ | ✅ |
+| Hook | Rollup | Vite | Webpack 4 | Webpack 5 | Esbuild |
+| ---- | :----: | :--: | :-------: | :-------: | :-----: |
+| [`buildStart`](https://rollupjs.org/guide/en/#buildstart) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [`buildEnd`](https://rollupjs.org/guide/en/#buildend) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `transformInclude`* | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [`transform`](https://rollupjs.org/guide/en/#transformers) | ✅ | ✅ | ✅ | ✅ | ✅\*\*\* |
+| [`enforce`](https://rollupjs.org/guide/en/#enforce) | ❌\*\* | ✅ | ✅ | ✅ | ❌\*\* |
+| [`resolveId`](https://rollupjs.org/guide/en/#resolveid) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [`load`](https://rollupjs.org/guide/en/#load) | ✅ | ✅ | ✅ | ✅ | ✅\*\*\* |
 
 - *: Webpack's id filter is outside of loader logic; an additional hook is needed for better perf on Webpack. In Rollup and Vite, this hook has been polyfilled to match the behaviors. See for following usage examples.
-- **: Rollup does not support using `enforce` to control the order of plugins. Users need to maintain the order manually.
+- **: Rollup and esbuild do not support using `enforce` to control the order of plugins. Users need to maintain the order manually.
+- ***: Although esbuild can handle both JavaScript and CSS and many other file formats, you can only return JavaScript in `load` and `transform` results.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^16.11.4",
     "chalk": "^4.1.2",
     "enhanced-resolve": "^5.8.3",
+    "esbuild": "^0.14.8",
     "eslint": "^8.1.0",
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
@@ -54,11 +55,15 @@
     "webpack-cli": "^4.9.1"
   },
   "peerDependencies": {
+    "esbuild": "^0.14.8",
     "rollup": "^2.50.0",
     "vite": "^2.3.0",
     "webpack": "4 || 5"
   },
   "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    },
     "rollup": {
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "webpack-virtual-modules": "^0.4.3"
   },
   "devDependencies": {
+    "@ampproject/remapping": "^1.0.2",
     "@nuxtjs/eslint-config-typescript": "^7.0.2",
     "@types/express": "^4.17.13",
     "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "webpack-cli": "^4.9.1"
   },
   "peerDependencies": {
-    "esbuild": "^0.14.8",
+    "esbuild": ">=0.13",
     "rollup": "^2.50.0",
     "vite": "^2.3.0",
     "webpack": "4 || 5"

--- a/scripts/buildFixtures.ts
+++ b/scripts/buildFixtures.ts
@@ -23,6 +23,8 @@ async function run () {
     execSync('npx rollup -c', { cwd: path, stdio: 'inherit' })
     console.log(c.blue.inverse.bold`\n  Webpack  `, name, '\n')
     execSync('npx webpack', { cwd: path, stdio: 'inherit' })
+    console.log(c.yellow.inverse.bold`\n  Esbuild  `, name, '\n')
+    execSync('node esbuild.config.js', { cwd: path, stdio: 'inherit' })
   }
 }
 

--- a/src/define.ts
+++ b/src/define.ts
@@ -1,3 +1,4 @@
+import { getEsbuildPlugin } from './esbuild'
 import { getRollupPlugin } from './rollup'
 import { UnpluginInstance, UnpluginFactory } from './types'
 import { getVitePlugin } from './vite'
@@ -7,6 +8,9 @@ export function createUnplugin<UserOptions = {}> (
   factory: UnpluginFactory<UserOptions>
 ): UnpluginInstance<UserOptions> {
   return {
+    get esbuild () {
+      return getEsbuildPlugin(factory)
+    },
     get rollup () {
       return getRollupPlugin(factory)
     },

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -40,7 +40,7 @@ export function getEsbuildPlugin <UserOptions = {}> (
           }
 
           if (plugin.load || plugin.transform) {
-            onLoad({ filter: onLoadFilter, namespace: plugin.name }, async (args) => {
+            onLoad({ filter: onLoadFilter }, async (args) => {
               const errors: PartialMessage[] = []
               const warnings: PartialMessage[] = []
               const pluginContext: UnpluginContext = {

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -4,7 +4,7 @@ import type { PartialMessage } from 'esbuild'
 import type { SourceMap } from 'rollup'
 import type { RawSourceMap } from '@ampproject/remapping/dist/types/types'
 import type { UnpluginContext, UnpluginContextMeta, UnpluginFactory, UnpluginInstance } from '../types'
-import { combineSourcemaps, fixSourceMap } from './utils'
+import { combineSourcemaps, fixSourceMap, guessLoader } from './utils'
 
 export function getEsbuildPlugin <UserOptions = {}> (
   factory: UnpluginFactory<UserOptions>
@@ -78,9 +78,7 @@ export function getEsbuildPlugin <UserOptions = {}> (
                   map = fixSourceMap(map as RawSourceMap)
                   code += `\n//# sourceMappingURL=${map.toUrl()}`
                 }
-                // loader: 'default' makes esbuild use the corresponding loader
-                // to the id's extname. this is required for jsx plugins
-                return { contents: code, errors, warnings, loader: 'default', resolveDir }
+                return { contents: code, errors, warnings, loader: guessLoader(args.path), resolveDir }
               }
 
               if (!plugin.transformInclude || plugin.transformInclude(args.path)) {
@@ -118,7 +116,7 @@ export function getEsbuildPlugin <UserOptions = {}> (
                   map = fixSourceMap(map as RawSourceMap)
                   code += `\n//# sourceMappingURL=${map.toUrl()}`
                 }
-                return { contents: code, errors, warnings, loader: 'default', resolveDir }
+                return { contents: code, errors, warnings, loader: guessLoader(args.path), resolveDir }
               }
             })
           }

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -1,0 +1,98 @@
+import fs from 'fs'
+import type { PartialMessage } from 'esbuild'
+import type { SourceMap } from 'rollup'
+import type { UnpluginContext, UnpluginContextMeta, UnpluginFactory, UnpluginInstance } from '../types'
+
+export function getEsbuildPlugin <UserOptions = {}> (
+  factory: UnpluginFactory<UserOptions>
+): UnpluginInstance<UserOptions>['esbuild'] {
+  return (userOptions?: UserOptions) => {
+    const meta: UnpluginContextMeta = {
+      framework: 'esbuild'
+    }
+    const plugin = factory(userOptions, meta)
+
+    return {
+      name: plugin.name,
+      setup:
+        plugin.esbuild?.setup ??
+        function setup ({ onStart, onEnd, onResolve, onLoad }) {
+          const onResolveFilter = plugin.esbuild?.onResolveFilter ?? /.*/
+          const onLoadFilter = plugin.esbuild?.onLoadFilter ?? /.*/
+
+          if (plugin.buildStart) {
+            onStart(plugin.buildStart)
+          }
+
+          if (plugin.buildEnd) {
+            onEnd(plugin.buildEnd)
+          }
+
+          if (plugin.resolveId) {
+            onResolve({ filter: onResolveFilter }, async (args) => {
+              const result = await plugin.resolveId!(args.path, args.importer)
+              if (typeof result === 'string') {
+                return { path: result, namespace: plugin.name }
+              } else if (typeof result === 'object' && result !== null) {
+                return { path: result.id, external: result.external, namespace: plugin.name }
+              }
+            })
+          }
+
+          if (plugin.load || plugin.transform) {
+            onLoad({ filter: onLoadFilter, namespace: plugin.name }, async (args) => {
+              const errors: PartialMessage[] = []
+              const warnings: PartialMessage[] = []
+              const pluginContext: UnpluginContext = {
+                error (message) { errors.push({ text: String(message) }) },
+                warn (message) { warnings.push({ text: String(message) }) }
+              }
+
+              let code: string | undefined, map: SourceMap | null | undefined
+
+              if (plugin.load) {
+                const result = await plugin.load.call(pluginContext, args.path)
+                if (typeof result === 'string') {
+                  code = result
+                } else if (typeof result === 'object' && result !== null) {
+                  code = result.code
+                  map = result.map
+                }
+              }
+
+              if (!plugin.transform) {
+                if (map) {
+                  code += `\n//# sourceMappingURL=${map.toUrl()}`
+                }
+                // The default loader is 'js', should we change it to 'default'?
+                return { contents: code, errors, warnings }
+              }
+
+              if (!plugin.transformInclude || plugin.transformInclude(args.path)) {
+                if (!code) {
+                  // What about binary files? (like images)
+                  code = await fs.promises.readFile(args.path, 'utf8')
+                }
+
+                const result = await plugin.transform.call(pluginContext, code, args.path)
+                if (typeof result === 'string') {
+                  code = result
+                } else if (typeof result === 'object' && result !== null) {
+                  code = result.code
+                  map = result.map
+                }
+                // Merge source maps?
+              }
+
+              if (code) {
+                if (map) {
+                  code += `\n//# sourceMappingURL=${map.toUrl()}`
+                }
+                return { contents: code, errors, warnings }
+              }
+            })
+          }
+        }
+    }
+  }
+}

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -92,6 +92,13 @@ export function getEsbuildPlugin <UserOptions = {}> (
                       result.map as RawSourceMap,
                       map as RawSourceMap
                     ]) as SourceMap
+                    // add missing toUrl() to the merged map
+                    Object.defineProperty(map, 'toUrl', {
+                      enumerable: false,
+                      value: function toUrl () {
+                        return 'data:application/json;charset=utf-8;base64,' + Buffer.from(this.toString()).toString('base64')
+                      }
+                    })
                   } else {
                     map = result.map
                   }

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -63,9 +63,12 @@ export function getEsbuildPlugin <UserOptions = {}> (
               }
 
               if (!plugin.transform) {
+                if (code === undefined) {
+                  return null
+                }
                 if (map) {
                   // fix missing sourcesContent, esbuild depends on it
-                  if (code && (!map.sourcesContent || map.sourcesContent.length === 0)) {
+                  if (!map.sourcesContent || map.sourcesContent.length === 0) {
                     map.sourcesContent = [code]
                   }
                   code += `\n//# sourceMappingURL=${map.toUrl()}`

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -99,10 +99,10 @@ export function getEsbuildPlugin <UserOptions = {}> (
                   // if we already got sourcemap from `load()`,
                   // combine the two sourcemaps
                   if (map && result.map) {
-                    map = fixSourceMap(combineSourcemaps(args.path, [
+                    map = combineSourcemaps(args.path, [
                       result.map as RawSourceMap,
                       map as RawSourceMap
-                    ]))
+                    ]) as SourceMap
                   } else {
                     // otherwise, we always keep the last one, even if it's empty
                     map = result.map

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -36,7 +36,7 @@ export function fixSourceMap (map: RawSourceMap): SourceMap {
   })
   Object.defineProperty(map, 'toUrl', {
     enumerable: false,
-    value: function toString () {
+    value: function toUrl () {
       return 'data:application/json;charset=utf-8;base64,' + Buffer.from(this.toString()).toString('base64')
     }
   })

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -3,6 +3,25 @@ import type {
   DecodedSourceMap,
   RawSourceMap
 } from '@ampproject/remapping/dist/types/types'
+import type { SourceMap } from 'rollup'
+
+// `load` and `transform` may return a sourcemap without toString and toUrl,
+// but esbuild needs them, we fix the two methods
+export function fixSourceMap (map: RawSourceMap): SourceMap {
+  Object.defineProperty(map, 'toString', {
+    enumerable: false,
+    value: function toString () {
+      return JSON.stringify(this)
+    }
+  })
+  Object.defineProperty(map, 'toUrl', {
+    enumerable: false,
+    value: function toString () {
+      return 'data:application/json;charset=utf-8;base64,' + Buffer.from(this.toString()).toString('base64')
+    }
+  })
+  return map as SourceMap
+}
 
 // taken from https://github.com/vitejs/vite/blob/71868579058512b51991718655e089a78b99d39c/packages/vite/src/node/utils.ts#L525
 const nullSourceMap: RawSourceMap = {

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -1,0 +1,50 @@
+import remapping from '@ampproject/remapping'
+import type {
+  DecodedSourceMap,
+  RawSourceMap
+} from '@ampproject/remapping/dist/types/types'
+
+// taken from https://github.com/vitejs/vite/blob/71868579058512b51991718655e089a78b99d39c/packages/vite/src/node/utils.ts#L525
+const nullSourceMap: RawSourceMap = {
+  names: [],
+  sources: [],
+  mappings: '',
+  version: 3
+}
+export function combineSourcemaps (
+  filename: string,
+  sourcemapList: Array<DecodedSourceMap | RawSourceMap>
+): RawSourceMap {
+  if (
+    sourcemapList.length === 0 ||
+    sourcemapList.every(m => m.sources.length === 0)
+  ) {
+    return { ...nullSourceMap }
+  }
+
+  // We don't declare type here so we can convert/fake/map as RawSourceMap
+  let map // : SourceMap
+  let mapIndex = 1
+  const useArrayInterface =
+    sourcemapList.slice(0, -1).find(m => m.sources.length !== 1) === undefined
+  if (useArrayInterface) {
+    map = remapping(sourcemapList, () => null, true)
+  } else {
+    map = remapping(
+      sourcemapList[0],
+      function loader (sourcefile) {
+        if (sourcefile === filename && sourcemapList[mapIndex]) {
+          return sourcemapList[mapIndex++]
+        } else {
+          return { ...nullSourceMap }
+        }
+      },
+      true
+    )
+  }
+  if (!map.file) {
+    delete map.file
+  }
+
+  return map as RawSourceMap
+}

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -1,9 +1,29 @@
+import { extname } from 'path'
 import remapping from '@ampproject/remapping'
 import type {
   DecodedSourceMap,
   RawSourceMap
 } from '@ampproject/remapping/dist/types/types'
+import type { Loader } from 'esbuild'
 import type { SourceMap } from 'rollup'
+
+const ExtToLoader: Record<string, Loader> = {
+  '.js': 'js',
+  '.mjs': 'js',
+  '.cjs': 'js',
+  '.jsx': 'jsx',
+  '.ts': 'ts',
+  '.cts': 'ts',
+  '.mts': 'ts',
+  '.tsx': 'tsx',
+  '.css': 'css',
+  '.json': 'json',
+  '.txt': 'text'
+}
+
+export function guessLoader (id: string): Loader {
+  return ExtToLoader[extname(id).toLowerCase()] || 'js'
+}
 
 // `load` and `transform` may return a sourcemap without toString and toUrl,
 // but esbuild needs them, we fix the two methods

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,11 @@
 import type { Plugin as RollupPlugin, PluginContextMeta as RollupContextMeta, SourceMap } from 'rollup'
 import type { Compiler as WebpackCompiler, WebpackPluginInstance } from 'webpack'
 import type { Plugin as VitePlugin } from 'vite'
+import type { Plugin as EsbuildPlugin } from 'esbuild'
 import type VirtualModulesPlugin from 'webpack-virtual-modules'
 
 export {
+  EsbuildPlugin,
   RollupPlugin,
   VitePlugin,
   WebpackCompiler
@@ -29,6 +31,12 @@ export interface UnpluginOptions {
   rollup?: Partial<RollupPlugin>
   webpack?: (compiler: WebpackCompiler) => void
   vite?: Partial<VitePlugin>
+  esbuild?: {
+    // using regexp in esbuild improves performance
+    onResolveFilter?: RegExp
+    onLoadFilter?: RegExp
+    setup?: EsbuildPlugin['setup']
+  }
 }
 
 export interface ResolvedUnpluginOptions extends UnpluginOptions {
@@ -44,11 +52,12 @@ export interface UnpluginInstance<UserOptions> {
   rollup: (options?: UserOptions) => RollupPlugin;
   webpack: (options?: UserOptions) => WebpackPluginInstance;
   vite: (options?: UserOptions) => VitePlugin;
+  esbuild: (options?: UserOptions) => EsbuildPlugin;
   raw: UnpluginFactory<UserOptions>
 }
 
 export interface UnpluginContextMeta extends Partial<RollupContextMeta> {
-  framework: 'rollup' | 'vite' | 'webpack'
+  framework: 'rollup' | 'vite' | 'webpack' | 'esbuild'
   webpack?: {
     compiler: WebpackCompiler
   }

--- a/test/fixtures/transform/__test__/build.test.ts
+++ b/test/fixtures/transform/__test__/build.test.ts
@@ -24,4 +24,11 @@ describe('transform build', () => {
     expect(content).toContain('NON-TARGET: __UNPLUGIN__')
     expect(content).toContain('TARGET: [Injected Webpack]')
   })
+
+  it('esbuild', async () => {
+    const content = await fs.readFile(r('esbuild/main.js'), 'utf-8')
+
+    expect(content).toContain('NON-TARGET: __UNPLUGIN__')
+    expect(content).toContain('TARGET: [Injected Esbuild]')
+  })
 })

--- a/test/fixtures/transform/esbuild.config.js
+++ b/test/fixtures/transform/esbuild.config.js
@@ -1,0 +1,12 @@
+const { build } = require('esbuild')
+const { esbuild } = require('./unplugin')
+
+build({
+  entryPoints: ['src/main.js'],
+  bundle: true,
+  outdir: 'dist/esbuild',
+  sourcemap: true,
+  plugins: [
+    esbuild({ msg: 'Esbuild' })
+  ]
+})

--- a/test/fixtures/virtual-module/__test__/build.test.ts
+++ b/test/fixtures/virtual-module/__test__/build.test.ts
@@ -24,4 +24,11 @@ describe('virtual-module build', () => {
     expect(content).toContain('VIRTUAL:ONE')
     expect(content).toContain('VIRTUAL:TWO')
   })
+
+  it('esbuild', async () => {
+    const content = await fs.readFile(r('esbuild/main.js'), 'utf-8')
+
+    expect(content).toContain('VIRTUAL:ONE')
+    expect(content).toContain('VIRTUAL:TWO')
+  })
 })

--- a/test/fixtures/virtual-module/esbuild.config.js
+++ b/test/fixtures/virtual-module/esbuild.config.js
@@ -1,0 +1,12 @@
+const { build } = require('esbuild')
+const { esbuild } = require('./unplugin')
+
+build({
+  entryPoints: ['src/main.js'],
+  bundle: true,
+  outdir: 'dist/esbuild',
+  sourcemap: true,
+  plugins: [
+    esbuild()
+  ]
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,85 +2048,175 @@ esbuild-android-arm64@0.13.9:
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.9.tgz#6cc4a0c623332c0830a311ddd8242b1f496ff940"
   integrity sha512-Ty0hKldtjJVLHwUwbKR4GFPiXBo5iQ3aE1OLBar9lh3myaRkUGEb+Ypl74LEKa0+t/9lS3Ev1N5+5P2Sq6UvNQ==
 
+esbuild-android-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.8.tgz#69324e08ba68c7d9a541e7b825d7235b83e17bd6"
+  integrity sha512-tAEoSHnPBSH0cCAFa/aYs3LPsoTY4SwsP6wDKi4PaelbQYNJjqNpAeweyJ8l98g1D6ZkLyqsHbkYj+209sezkA==
+
 esbuild-darwin-64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.9.tgz#df44297c2438032cda2b21548a82bb007e2105cc"
   integrity sha512-Ay0/b98v0oYp3ApXNQ7QPbaSkCT9WjBU6h8bMB1SYrQ/PmHgwph91fb9V0pfOLKK1rYWypfrNbI0MyT2tWN+rQ==
+
+esbuild-darwin-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.8.tgz#7176b692b9de746ba2f9dd4dd81dc4f1b7670786"
+  integrity sha512-t7p7WzTb+ybiD/irkMt5j/NzB+jY+8yPTsrXk5zCOH1O7DdthRnAUJ7pJPwImdL7jAGRbLtYRxUPgCHs/0qUPw==
 
 esbuild-darwin-arm64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.9.tgz#704ef404a6a38eda190d40ed354e7f2c1c839081"
   integrity sha512-nJB8chaJdWathCe6EyIiMIqfyEzbuXPyNsPlL3bYRB1zFCF8feXT874D4IHbJ/w8B6BpY3sM1Clr/I/DK8E4ow==
 
+esbuild-darwin-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.8.tgz#59167584e58428877e48e05c4cca58755f843327"
+  integrity sha512-5FeaT2zMUajKnBwUMSsjZev5iA38YHrDmXhkOCwZQIFUvhqojinqCrvv/X7dyxb1987bcY9KGwJ+EwDwd922HQ==
+
 esbuild-freebsd-64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.9.tgz#fbbf22c99e15f27d0f8a1a040d7961a86f0d3a4e"
   integrity sha512-ktaBujf12XLkVXLGx7WjFcmh1tt34tm7gP4pHkhvbzbHrq+BbXwcl4EsW+5JT9VNKl7slOGf4Qnua/VW7ZcnIw==
+
+esbuild-freebsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.8.tgz#00b7d6e00abba9c2eccc9acd576c796333671e9c"
+  integrity sha512-pGHBLSf7ynfyDZXUtbq/GsA2VIwQlWXrUj1AMcE0id47mRdEUM8/1ZuqMGZx63hRnNgtK9zNJ8OIu2c7qq76Qw==
 
 esbuild-freebsd-arm64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.9.tgz#809fff4c43653dbbf071ffce9f80a030b278098e"
   integrity sha512-vVa5zps4dmwpXwv/amxVpIWvFJuUPWQkpV+PYtZUW9lqjXsQ3LBHP51Q1cXZZBIrqwszLsEyJPa5GuDOY15hzQ==
 
+esbuild-freebsd-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.8.tgz#57f0cd5a1cb37fa2c0e84e780677fe62f1e8c894"
+  integrity sha512-g4GgAnrx6Gh1BjKJjJWgPnOR4tW2FcAx9wFvyUjRsIjB35gT+aAFR+P/zStu5OG9LnbS8Pvjd4wS68QIXk+2dA==
+
 esbuild-linux-32@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.9.tgz#f9fd3423481e51674e9817d5eea25689889a5f5a"
   integrity sha512-HxoW9QNqhO8VW1l7aBiYQH4lobeHq85+blZ4nlZ7sg5CNhGRRwnMlV6S08VYKz6V0YKnHb5OqJxx2HZuTZ7tgQ==
+
+esbuild-linux-32@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.8.tgz#bbf3e5d3fb30f949030d0c2241ac93a172917d56"
+  integrity sha512-wPfQJadF5vTzriw/B8Ide74PeAJlZW7czNx3NIUHkHlXb+En1SeIqNzl6jG9DuJUl57xD9Ucl9YJFEkFeX8eLg==
 
 esbuild-linux-64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.13.9.tgz#9d7f66866dae1abaff7cbc3749f2847d5fb72fd5"
   integrity sha512-L+eAR8o1lAUr9g64RXnBLuWZjAItAOWSUpvkchpa6QvSnXFA/nG6PgGsOBEqhDXl9qYEpGI0ReDrFkf8ByapvQ==
 
+esbuild-linux-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.8.tgz#08631e9e0da613603bcec782f29fecbc6f4596de"
+  integrity sha512-+RNuLk9RhRDL2kG+KTEYl5cIgF6AGLkRnKKWEu9DpCZaickONEqrKyQSVn410Hj105DLdW6qvIXQQHPycJhExg==
+
 esbuild-linux-arm64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.9.tgz#669202e71b9ced4d285bfd1d69de948e013ac28f"
   integrity sha512-IjbhZpW5VQYK4nVI4dj/mLvH5oXAIf57OI8BYVkCqrdVXJwR8nVrSqux3zJSY+ElrkOK3DtG9iTPpmqvBXaU0g==
+
+esbuild-linux-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.8.tgz#206d39c8dfbb7c72aa2f5fc52f7402b5b8a77366"
+  integrity sha512-BtWoKNYul9UoxUvQUSdSrvSmJyFL1sGnNPTSqWCg1wMe4kmc8UY2yVsXSSkKO8N2jtHxlgFyz/XhvNBzEwGVcw==
 
 esbuild-linux-arm@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.9.tgz#c3ceb56ec0e3dbd1a3a89dca6cb7fc0ca360bcc8"
   integrity sha512-DT0S+ufCVXatPZHjkCaBgZSFIV8FzY4GEHz/BlkitTWzUvT1dIUXjPIRPnqBUVa+0AyS1bZSfHzv9hTT4LHz7A==
 
+esbuild-linux-arm@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.8.tgz#e28e70420d187f5e403bfa4a72df676d53d707fd"
+  integrity sha512-HIct38SvUAIJbiTwV/PVQroimQo96TGtzRDAEZxTorB4vsAj1r8bd0keXExPU4RH7G0zIqC4loQQpWYL+nH4Vg==
+
 esbuild-linux-mips64le@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.9.tgz#bf4bd389ee14b67c5c77669952f2de6b2cc8a003"
   integrity sha512-ec9RgAM4r+fe1ZmG16qeMwEHdcIvqeW8tpnpkfSQu9T4487KtQF6lg3TQasTarrLLEe7Qpy+E+r4VwC8eeZySQ==
+
+esbuild-linux-mips64le@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.8.tgz#04997ac1a0df794a4d5e04d78015863d48490590"
+  integrity sha512-0DxnCl9XTvaQtsX6Qa+Phr5i9b04INwwSv2RbQ2UWRLoQ/037iaFzbmuhgrcmaGOcRwPkCa+4Qo5EgI01MUgsQ==
 
 esbuild-linux-ppc64le@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.9.tgz#465b7bdc70577da606b3b5d463028292b6d834ad"
   integrity sha512-7b2/wg8T1n/L1BgCWlMSez0aXfGkNjFuOqMBQdnTti3LRuUwzGJcrhRf/FdZGJ5/evML9mqu60vLRuXW1TdXCg==
 
+esbuild-linux-ppc64le@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.8.tgz#1827378feff9702c156047ba118c1f3bd74da67e"
+  integrity sha512-Uzr/OMj97Q0qoWLXCvXCKUY/z1SNI4iSZEuYylM5Nd71HGStL32XWq/MReJ0PYMvUMKKJicKSKw2jWM1uBQ84Q==
+
+esbuild-linux-s390x@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.8.tgz#200ac44cda59b81135b325c3a29d016969650876"
+  integrity sha512-vURka7aCA5DrRoOqOn6pXYwFlDSoQ4qnqam8AC0Ikn6tibutuhgar6M3Ek2DCuz9yqd396mngdYr5A8x2TPkww==
+
 esbuild-netbsd-64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.9.tgz#94f2dabe83520066cc1e1fae3ecff78695a8ebb1"
   integrity sha512-PiZu3h4+Szj0iZPgvuD2Y0isOXnlNetmF6jMcOwW54BScwynW24/baE+z7PfDyNFgjV04Ga2THdcpbKBDhgWQw==
+
+esbuild-netbsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.8.tgz#8159d8eae111f80ea6e4cbfa5d4cf658388a72d4"
+  integrity sha512-tjyDak2/pp0VUAhBW6/ueuReMd5qLHNlisXl5pq0Xn0z+kH9urA/t1igm0JassWbdMz123td5ZEQWoD9KbtOAw==
 
 esbuild-openbsd-64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.9.tgz#b47f6a641ca37358aeedb2b7c4bb73dd0682c6d5"
   integrity sha512-SJKN4Ez+ilY7mu+1gAdGQ9N6dktBfbEkiOAvw+hT7xHrNnTnrTGH0FT4qx9dazB9HX6D04L4PXmVOyynqi+oEQ==
 
+esbuild-openbsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.8.tgz#2a9498d881a3ab94927c724f34dd1160eef1f3b8"
+  integrity sha512-zAKKV15fIyAuDDga5rQv0lW2ufBWj/OCjqjDBb3dJf5SfoAi/DMIHuzmkKQeDQ+oxt9Rp1D7ZOlOBVflutFTqQ==
+
 esbuild-sunos-64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.9.tgz#b0df4a316b7c98eb490f4bd0db381cf2c391ae73"
   integrity sha512-9N0RjZ7cElE8ifrS0nBrLQgBMQNPiIIKO2GzLXy7Ms8AM3KjfLiV2G2+9O0B9paXjRAHchIwazTeOyeWb1vyWA==
+
+esbuild-sunos-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.8.tgz#2447de7d79848ad528c7d44caab4938eb8f5a0cc"
+  integrity sha512-xV41Wa8imziM/2dbWZjLKQbIETRgo5dE0oc/uPsgaecJhsrdA0VkGa/V432LJSUYv967xHDQdoRRl5tr80+NnQ==
 
 esbuild-windows-32@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.9.tgz#e229563e134e634f9748cc8315c691e2013259ef"
   integrity sha512-awxWs1kns+RfjhqBbTbdlePjqZrAE2XMaAQJNg9dtu+C7ghC3QKsqXbu0C26OuF5YeAdJcq9q+IdG6WPLjvj9w==
 
+esbuild-windows-32@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.8.tgz#3287281552d7e4c851b3106940ff5826f518043e"
+  integrity sha512-AxpdeLKQSyCZo7MzdOyV4OgEbEJcjnrS/2niAjbHESbjuS5P1DN/5vZoJ/JSWDVa/40OkBuHBhAXMx1HK3UDsg==
+
 esbuild-windows-64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.13.9.tgz#103ad3f13e1a0e44934b91f358e81dd201b86b34"
   integrity sha512-VmA9GQMCzOr8rFfD72Dum1+AWhJui7ZO6sYwp6rBHYu4vLmWITTSUsd/zgXXmZuHBPkkvxLJLF8XsKFCRKflJA==
 
+esbuild-windows-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.8.tgz#b4052868438b4f17b5c2a908cf344ed2bd267c38"
+  integrity sha512-/3pllNoy8mrz/E1rYalwiwwhzJBrYQhEapwAteHZbFVhGzYuB8F80e8x5eA8dhFHxDiZh1VzK+hREwwSt8UTQA==
+
 esbuild-windows-arm64@0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.9.tgz#545bb58848008258b339b1b00fcfe92c85bc7251"
   integrity sha512-P/jPY2JwmTpgEPh9BkXpCe690tcDSSo0K9BHTniSeEAEz26kPpqldVa4XDm0R+hNnFA7ecEgNskr4QAxE1ry0w==
+
+esbuild-windows-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.8.tgz#512d06097cb4b848526a37c48a47223f1c6cc667"
+  integrity sha512-lTm5naoNgaUvzIiax3XYIEebqwr3bIIEEtqUhzQ2UQ+JMBmvhr02w3sJIJqF3axTX6TgWrC1OtM7DYNvFG+aXA==
 
 esbuild@^0.13.2, esbuild@^0.13.4:
   version "0.13.9"
@@ -2150,6 +2240,30 @@ esbuild@^0.13.2, esbuild@^0.13.4:
     esbuild-windows-32 "0.13.9"
     esbuild-windows-64 "0.13.9"
     esbuild-windows-arm64 "0.13.9"
+
+esbuild@^0.14.8:
+  version "0.14.8"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.14.8.tgz#f60a07ca9400d61d09a98f96d666c50613972550"
+  integrity sha512-stMsCBmxwaMpeK8GC/49L/cRGIwsHwoEN7Twk5zDTHlm/63c0KXFKzDC8iM2Mi3fyCKwS002TAH6IlAvqR6t3g==
+  optionalDependencies:
+    esbuild-android-arm64 "0.14.8"
+    esbuild-darwin-64 "0.14.8"
+    esbuild-darwin-arm64 "0.14.8"
+    esbuild-freebsd-64 "0.14.8"
+    esbuild-freebsd-arm64 "0.14.8"
+    esbuild-linux-32 "0.14.8"
+    esbuild-linux-64 "0.14.8"
+    esbuild-linux-arm "0.14.8"
+    esbuild-linux-arm64 "0.14.8"
+    esbuild-linux-mips64le "0.14.8"
+    esbuild-linux-ppc64le "0.14.8"
+    esbuild-linux-s390x "0.14.8"
+    esbuild-netbsd-64 "0.14.8"
+    esbuild-openbsd-64 "0.14.8"
+    esbuild-sunos-64 "0.14.8"
+    esbuild-windows-32 "0.14.8"
+    esbuild-windows-64 "0.14.8"
+    esbuild-windows-arm64 "0.14.8"
 
 escalade@^3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-1.0.2.tgz#a7ebbadb71517dd63298420868f27d98fe230a0a"
+  integrity sha512-SncaVxs+E3EdoA9xJgHfWPxZfowAgeIsd71VpqCKP6KNKm6s7zSqqvUc70UpKUFsrV3dAmy6qxHoIj5NG+3DiA==
+  dependencies:
+    "@jridgewell/resolve-uri" "1.0.0"
+    sourcemap-codec "1.4.8"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
@@ -545,6 +553,11 @@
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
+
+"@jridgewell/resolve-uri@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz#3fdf5798f0b49e90155896f6291df186eac06c83"
+  integrity sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5085,7 +5098,7 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@1.4.8, sourcemap-codec@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==


### PR DESCRIPTION
This pr adds esbuild support for unplugin, which resolves #25 .

Some Todos:

- [x] What version of esbuild should be set in `peerDependencies`?
- [x] Esbuild supports bundling js **and css**, while we cannot know the module type on load (especially if it is provided by a virtual file). We just assume the results of `load` and `transform` are always js variants (js, jsx, ts, tsx) then append the sourcemap url to the code.
- [x] By esbuild's design the `onLoad` callback will be applied to all kind of resources, including the binary ones (images, etc.). So the plugin has a chance to handle them too. Plugin authors need to make sure the result of the `load` and `transform` are valid javascript code.
- [x] `plugin.load` and `plugin.transform` both returns code **and map**, we merge the two sourcemaps if both present. Otherwise only the last one will be kept.

Hope to hear your thoughts!