### PR TITLE
fix: avoid redefining property

### DIFF
--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -28,18 +28,22 @@ export function guessLoader (id: string): Loader {
 // `load` and `transform` may return a sourcemap without toString and toUrl,
 // but esbuild needs them, we fix the two methods
 export function fixSourceMap (map: RawSourceMap): SourceMap {
-  Object.defineProperty(map, 'toString', {
-    enumerable: false,
-    value: function toString () {
-      return JSON.stringify(this)
-    }
-  })
-  Object.defineProperty(map, 'toUrl', {
-    enumerable: false,
-    value: function toUrl () {
-      return 'data:application/json;charset=utf-8;base64,' + Buffer.from(this.toString()).toString('base64')
-    }
-  })
+  if (!map.toString) {
+    Object.defineProperty(map, 'toString', {
+      enumerable: false,
+      value: function toString () {
+        return JSON.stringify(this)
+      }
+    })
+  }
+  if (!(map as SourceMap).toUrl) {
+    Object.defineProperty(map, 'toUrl', {
+      enumerable: false,
+      value: function toUrl () {
+        return 'data:application/json;charset=utf-8;base64,' + Buffer.from(this.toString()).toString('base64')
+      }
+    })
+  }
   return map as SourceMap
 }
 

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -28,7 +28,7 @@ export function guessLoader (id: string): Loader {
 // `load` and `transform` may return a sourcemap without toString and toUrl,
 // but esbuild needs them, we fix the two methods
 export function fixSourceMap (map: RawSourceMap): SourceMap {
-  if (!map.toString) {
+  if (!('toString' in map)) {
     Object.defineProperty(map, 'toString', {
       enumerable: false,
       value: function toString () {

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -36,7 +36,7 @@ export function fixSourceMap (map: RawSourceMap): SourceMap {
       }
     })
   }
-  if (!(map as SourceMap).toUrl) {
+  if (!('toUrl' in map)) {
     Object.defineProperty(map, 'toUrl', {
       enumerable: false,
       value: function toUrl () {


### PR DESCRIPTION
fix error 
```
✘ [ERROR] [plugin unplugin-vue] Cannot redefine property: toString
    at Function.defineProperty (<anonymous>)
    at fixSourceMap (file://some/path/node_modules/.pnpm/unplugin@0.3.0_f1163fc619aae5be7a2291f98077607c/node_modules/unplugin/dist/index.mjs:472:10)
```