### PR TITLE
fix: filter out illegal sourcemap items

### DIFF
--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -62,6 +62,8 @@ export function combineSourcemaps (
   filename: string,
   sourcemapList: Array<DecodedSourceMap | RawSourceMap>
 ): RawSourceMap {
+  sourcemapList = sourcemapList.filter(m => m.sources)
+
   if (
     sourcemapList.length === 0 ||
     sourcemapList.every(m => m.sources.length === 0)


### PR DESCRIPTION
filter ou illegal sourcemap like this

```js
{ mappings: '' }
```