### PR TITLE
feat: respect resolved id instead of raw request id

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -106,7 +106,7 @@ export function getWebpackPlugin<UserOptions = {}> (
                 // if the resolved module is not exists,
                 // we treat it as a virtual module
                 if (!fs.existsSync(resolved)) {
-                  resolved = plugin.__virtualModulePrefix + id
+                  resolved = plugin.__virtualModulePrefix + backSlash(resolved)
                   // webpack virtual module should pass in the correct path
                   plugin.__vfs!.writeModule(resolved, '')
                   plugin.__vfsModules!.add(resolved)


### PR DESCRIPTION
I could be missing something, it seems more reasonable to use resolved id so that plugin author have more control over `resolveId` hook.

### Problem

Have a use case for virtual routes as below:

```ts
// App.tsx
import routes from '~routes'

// webpack.config.js
// `~routes` w/o extension will be matched by CRA's file-loader 
// https://github.com/facebook/create-react-app/blob/eee8491d57d67dd76f0806a7512eaba2ce9c36f0/packages/react-scripts/config/webpack.config.js#L509


// Plugin.ts
{
  resolveId(id: string) {
    if (id === '~routes') 
      return '~routes.mjs'
    return null 
  }
}
```

###