### PR TITLE
fix: keep the same slash with system

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -4,7 +4,7 @@ import { resolve, dirname } from 'path'
 import VirtualModulesPlugin from 'webpack-virtual-modules'
 import type { Resolver, ResolveRequest } from 'enhanced-resolve'
 import type { UnpluginContextMeta, UnpluginInstance, UnpluginFactory, WebpackCompiler, ResolvedUnpluginOptions } from '../types'
-import { slash, backSlash } from './utils'
+import { slash } from './utils'
 import genContext from './genContext'
 const _dirname = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
 const TRANSFORM_LOADER = resolve(_dirname, 'webpack/loaders/transform.js')
@@ -86,7 +86,7 @@ export function getWebpackPlugin<UserOptions = {}> (
                   return callback()
                 }
 
-                const id = backSlash(request.request)
+                const id = slash(request.request)
 
                 // filter out invalid requests
                 if (id.startsWith(plugin.__virtualModulePrefix)) {
@@ -106,7 +106,7 @@ export function getWebpackPlugin<UserOptions = {}> (
                 // if the resolved module is not exists,
                 // we treat it as a virtual module
                 if (!fs.existsSync(resolved)) {
-                  resolved = plugin.__virtualModulePrefix + backSlash(resolved)
+                  resolved = plugin.__virtualModulePrefix + slash(resolved)
                   // webpack virtual module should pass in the correct path
                   plugin.__vfs!.writeModule(resolved, '')
                   plugin.__vfsModules!.add(resolved)

--- a/src/webpack/utils.ts
+++ b/src/webpack/utils.ts
@@ -1,7 +1,5 @@
-export function slash (path: string) {
-  return path.replace(/\\/g, '/')
-}
+import { sep } from 'path'
 
-export function backSlash (path: string) {
-  return path.replace(/\//g, '\\')
+export function slash (path: string) {
+  return path.replace(/[\\/]/g, sep)
 }


### PR DESCRIPTION
Forcing the direction of the slash to be specified can cause inconsistencies on different systems

Example, the methods **backSlash** always added a **to right** slash in the path end, in linux, this is wrong path charcter

https://github.com/unjs/unplugin/blob/6e419d1ac2498fc4d4052800e9b7912e99c1e64b/src/webpack/index.ts#L106-L113

https://github.com/unocss/unocss/issues/797
https://github.com/unocss/unocss/issues/931