### PR TITLE
fix: concat raw query for virtual module request

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -104,6 +104,14 @@ export function getWebpackPlugin<UserOptions = {}> (
                 // TODO: support external
                 // const isExternal = typeof result === 'string' ? false : result.external === true
 
+                // make sure resolved without query
+                let resolvedQuery = ''
+                const queryIndex = resolved.indexOf('?')
+                if (queryIndex >= 0) {
+                  resolvedQuery = resolved.slice(queryIndex)
+                  resolved = resolved.slice(0, queryIndex)
+                }
+
                 // if the resolved module is not exists,
                 // we treat it as a virtual module
                 if (!fs.existsSync(resolved)) {
@@ -113,17 +121,11 @@ export function getWebpackPlugin<UserOptions = {}> (
                   plugin.__vfsModules!.add(resolved)
                 }
 
-                let query = ''
-                const queryIndex = id.indexOf('?')
-                if (queryIndex >= 0) {
-                  query = id.slice(queryIndex)
-                }
-
                 // construct the new request
                 const newRequest = {
                   ...request,
-                  // concat raw query for newRequest.request
-                  request: resolved + query
+                  // concat resolved query for newRequest.request
+                  request: resolved + resolvedQuery
                 }
 
                 // redirect the resolver

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -113,10 +113,17 @@ export function getWebpackPlugin<UserOptions = {}> (
                   plugin.__vfsModules!.add(resolved)
                 }
 
+                let query = ''
+                const queryIndex = id.indexOf('?')
+                if(queryIndex >= 0) {
+                  query = id.slice(queryIndex)
+                }
+
                 // construct the new request
                 const newRequest = {
                   ...request,
-                  request: resolved
+                  // concat raw query for newRequest.request
+                  request: resolved + query
                 }
 
                 // redirect the resolver

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -115,7 +115,7 @@ export function getWebpackPlugin<UserOptions = {}> (
 
                 let query = ''
                 const queryIndex = id.indexOf('?')
-                if(queryIndex >= 0) {
+                if (queryIndex >= 0) {
                   query = id.slice(queryIndex)
                 }
 


### PR DESCRIPTION
Plugin.resolveId returns resource path without query and used directly as the new request for uno.css virtual module, raw request query will lost and may disturb some other compile processes rely on this.

In my opinion, raw request query should be preserved after resolve, to avoid problems mentioned above.