### PR TITLE
feat: add `isEntry` flag to `resolveId` hook

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -94,7 +94,14 @@ export function getEsbuildPlugin <UserOptions = {}> (
 
           if (plugin.resolveId) {
             onResolve({ filter: onResolveFilter }, async (args) => {
-              const result = await plugin.resolveId!(args.path, args.importer)
+              const isEntry = args.kind === 'entry-point'
+              const result = await plugin.resolveId!(
+                args.path,
+                // We explicitly have this if statement here for consistency with the integration of other bundelers.
+                // Here, `args.importer` is just an empty string on entry files whereas the euqivalent on other bundlers is `undefined.`
+                isEntry ? undefined : args.importer,
+                { isEntry }
+              )
               if (typeof result === 'string') {
                 return { path: result, namespace: plugin.name }
               } else if (typeof result === 'object' && result !== null) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface UnpluginOptions {
   transformInclude?: (id: string) => boolean;
   transform?: (this: UnpluginBuildContext & UnpluginContext, code: string, id: string) => Thenable<TransformResult>;
   load?: (this: UnpluginBuildContext & UnpluginContext, id: string) => Thenable<TransformResult>
-  resolveId?: (id: string, importer?: string) => Thenable<string | ExternalIdResult | null | undefined>
+  resolveId?: (id: string, importer: string | undefined, options: { isEntry: boolean }) => Thenable<string | ExternalIdResult | null | undefined>
   watchChange?: (this: UnpluginBuildContext, id: string, change: {event: 'create' | 'update' | 'delete'}) => void
 
   // framework specify extends

--- a/test/unit-tests/resolve-id/resolve-id.test.ts
+++ b/test/unit-tests/resolve-id/resolve-id.test.ts
@@ -20,26 +20,26 @@ function checkResolveIdHook (resolveIdCallback): void {
   expect.assertions(4)
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
-    expect.stringMatching(/(?:\/|\\\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     undefined,
     expect.objectContaining({ isEntry: true })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './proxy-export',
-    expect.stringMatching(/(?:\/|\\\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     expect.objectContaining({ isEntry: false })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './default-export',
-    expect.stringMatching(/(?:\/|\\\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     expect.objectContaining({ isEntry: false })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './named-export',
-    expect.stringMatching(/(?:\/|\\\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     expect.objectContaining({ isEntry: false })
   )
 }

--- a/test/unit-tests/resolve-id/resolve-id.test.ts
+++ b/test/unit-tests/resolve-id/resolve-id.test.ts
@@ -1,14 +1,12 @@
 import * as path from 'path'
-import { it, describe, expect, vi, afterEach } from 'vitest'
+import { it, describe, expect, vi, afterEach, Mock } from 'vitest'
 import * as vite from 'vite'
 import * as rollup from 'rollup'
 import { webpack } from 'webpack'
 import * as esbuild from 'esbuild'
 import { createUnplugin, UnpluginOptions } from '../../../src'
 
-const createUnpluginWithcallback = (
-  resolveIdCallback: UnpluginOptions['resolveId']
-) => {
+function createUnpluginWithCallback (resolveIdCallback: UnpluginOptions['resolveId']) {
   return createUnplugin(() => ({
     name: 'test-plugin',
     resolveId: resolveIdCallback
@@ -16,30 +14,30 @@ const createUnpluginWithcallback = (
 }
 
 // We extract this check because all bundlers should behave the same
-function checkResolveIdHook (resolveIdCallback): void {
+function checkResolveIdHook (resolveIdCallback: Mock): void {
   expect.assertions(4)
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
-    expect.stringMatching(/(?:\/|\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)entry\.js$/),
     undefined,
     expect.objectContaining({ isEntry: true })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './proxy-export',
-    expect.stringMatching(/(?:\/|\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)entry\.js$/),
     expect.objectContaining({ isEntry: false })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './default-export',
-    expect.stringMatching(/(?:\/|\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)proxy-export\.js$/),
     expect.objectContaining({ isEntry: false })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './named-export',
-    expect.stringMatching(/(?:\/|\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
+    expect.stringMatching(/(?:\/|\\)proxy-export\.js$/),
     expect.objectContaining({ isEntry: false })
   )
 }
@@ -51,7 +49,7 @@ describe('resolveId hook', () => {
 
   it('vite', async () => {
     const mockResolveIdHook = vi.fn(() => undefined)
-    const plugin = createUnpluginWithcallback(mockResolveIdHook).vite
+    const plugin = createUnpluginWithCallback(mockResolveIdHook).vite
 
     await vite.build({
       clearScreen: false,
@@ -70,7 +68,7 @@ describe('resolveId hook', () => {
 
   it('rollup', async () => {
     const mockResolveIdHook = vi.fn(() => undefined)
-    const plugin = createUnpluginWithcallback(mockResolveIdHook).rollup
+    const plugin = createUnpluginWithCallback(mockResolveIdHook).rollup
 
     await rollup.rollup({
       input: path.resolve(__dirname, 'test-src/entry.js'),
@@ -82,7 +80,7 @@ describe('resolveId hook', () => {
 
   it('webpack', async () => {
     const mockResolveIdHook = vi.fn(() => undefined)
-    const plugin = createUnpluginWithcallback(mockResolveIdHook).webpack
+    const plugin = createUnpluginWithCallback(mockResolveIdHook).webpack
 
     await new Promise((resolve) => {
       webpack(
@@ -99,7 +97,7 @@ describe('resolveId hook', () => {
 
   it('esbuild', async () => {
     const mockResolveIdHook = vi.fn(() => undefined)
-    const plugin = createUnpluginWithcallback(mockResolveIdHook).esbuild
+    const plugin = createUnpluginWithCallback(mockResolveIdHook).esbuild
 
     await esbuild.build({
       entryPoints: [path.resolve(__dirname, 'test-src/entry.js')],

--- a/test/unit-tests/resolve-id/resolve-id.test.ts
+++ b/test/unit-tests/resolve-id/resolve-id.test.ts
@@ -1,0 +1,113 @@
+import * as path from 'path'
+import { it, describe, expect, vi, afterEach } from 'vitest'
+import * as vite from 'vite'
+import * as rollup from 'rollup'
+import { webpack } from 'webpack'
+import * as esbuild from 'esbuild'
+import { createUnplugin, UnpluginOptions } from '../../../src'
+
+const createUnpluginWithcallback = (
+  resolveIdCallback: UnpluginOptions['resolveId']
+) => {
+  return createUnplugin(() => ({
+    name: 'test-plugin',
+    resolveId: resolveIdCallback
+  }))
+}
+
+// We extract this check because all bundlers should behave the same
+function checkResolveIdHook (resolveIdCallback): void {
+  expect.assertions(4)
+
+  expect(resolveIdCallback).toHaveBeenCalledWith(
+    expect.stringMatching(/\/entry\.js$/),
+    undefined,
+    expect.objectContaining({ isEntry: true })
+  )
+
+  expect(resolveIdCallback).toHaveBeenCalledWith(
+    './proxy-export',
+    expect.stringMatching(/\/entry\.js$/),
+    expect.objectContaining({ isEntry: false })
+  )
+
+  expect(resolveIdCallback).toHaveBeenCalledWith(
+    './default-export',
+    expect.stringMatching(/\/proxy-export\.js$/),
+    expect.objectContaining({ isEntry: false })
+  )
+
+  expect(resolveIdCallback).toHaveBeenCalledWith(
+    './named-export',
+    expect.stringMatching(/\/proxy-export\.js$/),
+    expect.objectContaining({ isEntry: false })
+  )
+}
+
+describe('resolveId hook', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('vite', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const plugin = createUnpluginWithcallback(mockResolveIdHook).vite
+
+    await vite.build({
+      clearScreen: false,
+      plugins: [{ ...plugin(), enforce: 'pre' }], // we need to define `enforce` here for the plugin to be run
+      build: {
+        lib: {
+          entry: path.resolve(__dirname, 'test-src/entry.js'),
+          name: 'TestLib'
+        },
+        write: false // don't output anything
+      }
+    })
+
+    checkResolveIdHook(mockResolveIdHook)
+  })
+
+  it('rollup', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const plugin = createUnpluginWithcallback(mockResolveIdHook).rollup
+
+    await rollup.rollup({
+      input: path.resolve(__dirname, 'test-src/entry.js'),
+      plugins: [plugin()]
+    })
+
+    checkResolveIdHook(mockResolveIdHook)
+  })
+
+  it('webpack', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const plugin = createUnpluginWithcallback(mockResolveIdHook).webpack
+
+    await new Promise((resolve) => {
+      webpack(
+        {
+          entry: path.resolve(__dirname, 'test-src/entry.js'),
+          plugins: [plugin()]
+        },
+        resolve
+      )
+    })
+
+    checkResolveIdHook(mockResolveIdHook)
+  })
+
+  it('esbuild', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const plugin = createUnpluginWithcallback(mockResolveIdHook).esbuild
+
+    await esbuild.build({
+      entryPoints: [path.resolve(__dirname, 'test-src/entry.js')],
+      plugins: [plugin()],
+      bundle: true, // actually traverse imports
+      write: false // don't pollute console
+    })
+
+    checkResolveIdHook(mockResolveIdHook)
+  })
+})

--- a/test/unit-tests/resolve-id/resolve-id.test.ts
+++ b/test/unit-tests/resolve-id/resolve-id.test.ts
@@ -20,26 +20,26 @@ function checkResolveIdHook (resolveIdCallback): void {
   expect.assertions(4)
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
-    expect.stringMatching(/\/entry\.js$/),
+    expect.stringMatching(/(?:\/|\\\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     undefined,
     expect.objectContaining({ isEntry: true })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './proxy-export',
-    expect.stringMatching(/\/entry\.js$/),
+    expect.stringMatching(/(?:\/|\\\\)entry\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     expect.objectContaining({ isEntry: false })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './default-export',
-    expect.stringMatching(/\/proxy-export\.js$/),
+    expect.stringMatching(/(?:\/|\\\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     expect.objectContaining({ isEntry: false })
   )
 
   expect(resolveIdCallback).toHaveBeenCalledWith(
     './named-export',
-    expect.stringMatching(/\/proxy-export\.js$/),
+    expect.stringMatching(/(?:\/|\\\\)proxy-export\.js$/), // regex to check path needs to be OS agnostic (unix/windows)
     expect.objectContaining({ isEntry: false })
   )
 }

--- a/test/unit-tests/resolve-id/test-src/default-export.js
+++ b/test/unit-tests/resolve-id/test-src/default-export.js
@@ -1,0 +1,1 @@
+export default 'some string'

--- a/test/unit-tests/resolve-id/test-src/entry.js
+++ b/test/unit-tests/resolve-id/test-src/entry.js
@@ -1,0 +1,3 @@
+import { named, proxiedDefault } from './proxy-export'
+
+process.stdout.write(JSON.stringify({ named, proxiedDefault }))

--- a/test/unit-tests/resolve-id/test-src/named-export.js
+++ b/test/unit-tests/resolve-id/test-src/named-export.js
@@ -1,0 +1,1 @@
+export const named = 'named export'

--- a/test/unit-tests/resolve-id/test-src/proxy-export.js
+++ b/test/unit-tests/resolve-id/test-src/proxy-export.js
@@ -1,0 +1,2 @@
+export { named } from './named-export'
+export { default as proxiedDefault } from './default-export'


### PR DESCRIPTION
This PR adds the `isEntry` flag of rollup's [`resolveId` hook](https://rollupjs.org/guide/en/#resolveid) to all of unplugin's supported tools.

- I "cleaned up" the webpack integration a bit. It didn't get a lot cleaner but the TS type inference got a bit better.
- Added a unit test stup for the `resolveId` hook. We could use similar setups to test the other hooks.

