### PR TITLE
fix: ensure consistent `id`s across hooks and bundlers

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -94,6 +94,12 @@ export function getEsbuildPlugin <UserOptions = {}> (
 
           if (plugin.resolveId) {
             onResolve({ filter: onResolveFilter }, async (args) => {
+              if (initialOptions.external?.includes(args.path)) {
+                // We don't want to call the `resolveId` hook for external modules, since rollup doesn't do
+                // that and we want to have consistent behaviour across bundlers
+                return undefined
+              }
+
               const isEntry = args.kind === 'entry-point'
               const result = await plugin.resolveId!(
                 args.path,

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,7 +1,8 @@
 /**
- * Flag that is replaced with a boolean during build time. __BUNDLED__ is true in the final library output, and it is
- * false when the library is ad-hoc transpiled, ie. during tests.
+ * Flag that is replaced with a boolean during build time.
+ * __DEV__ is false in the final library output, and it is
+ * true when the library is ad-hoc transpiled, ie. during tests.
  *
  * See "tsup.config.ts" and "vitest.config.ts" for more info.
  */
-declare const __BUNDLED__: boolean
+declare const __DEV__: boolean

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Flag that is replaced with a boolean during build time. __BUNDLED__ is true in the final library output, and it is
+ * false when the library is ad-hoc transpiled, ie. during tests.
+ *
+ * See "tsup.config.ts" and "vitest.config.ts" for more info.
+ */
+declare const __BUNDLED__: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,19 @@
+import { isAbsolute, normalize } from 'path'
+
+/**
+ * Normalizes a given path when it's absolute. Normalizing means returning a new path by converting
+ * the input path to the native os format. This is useful in cases where we want to normalize
+ * the `id` argument of a hook. Any absolute ids should be in the default format
+ * of the operating system. Any relative imports or node_module imports should remain
+ * untouched.
+ *
+ * @param path - Path to normalize.
+ * @returns a new normalized path.
+ */
+export function normalizeAbsolutePath (path: string) {
+  if (isAbsolute(path)) {
+    return normalize(path)
+  } else {
+    return path
+  }
+}

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -1,5 +1,7 @@
+import * as os from 'os'
+import { normalizeAbsolutePath } from '../utils'
 import { toRollupPlugin } from '../rollup'
-import { UnpluginInstance, UnpluginFactory, VitePlugin, UnpluginContextMeta } from '../types'
+import { UnpluginInstance, UnpluginFactory, UnpluginContextMeta } from '../types'
 
 export function getVitePlugin <UserOptions = {}> (
   factory: UnpluginFactory<UserOptions>
@@ -8,9 +10,36 @@ export function getVitePlugin <UserOptions = {}> (
     const meta: UnpluginContextMeta = {
       framework: 'vite'
     }
+
     const rawPlugin = factory(userOptions, meta)
 
-    const plugin = toRollupPlugin(rawPlugin, false) as VitePlugin
+    // On windows, Vite replaces backward slashes in paths/ids with forward slashes
+    // in the `load`, `transformInclude`, and `transform` hooks. The `resolveId` hook
+    // however has backwards slashes.
+    // To ensure consistent ids across all hooks, we replace the forward slashes
+    // in the `load`, `transformInclude`, and `transform` hooks with backward slashes
+    if (os.platform() === 'win32') {
+      if (rawPlugin.load) {
+        const _load = rawPlugin.load
+        rawPlugin.load = function (id, ...args) {
+          return _load.call(this, normalizeAbsolutePath(id), ...args)
+        }
+      }
+      if (rawPlugin.transformInclude) {
+        const _transformInclude = rawPlugin.transformInclude
+        rawPlugin.transformInclude = function (id, ...args) {
+          return _transformInclude.call(this, normalizeAbsolutePath(id), ...args)
+        }
+      }
+      if (rawPlugin.transform) {
+        const _transform = rawPlugin.transform
+        rawPlugin.transform = function (code, id, ...args) {
+          return _transform.call(this, code, normalizeAbsolutePath(id), ...args)
+        }
+      }
+    }
+
+    const plugin = toRollupPlugin(rawPlugin, false)
 
     if (rawPlugin.vite) {
       Object.assign(plugin, rawPlugin.vite)

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -1,7 +1,5 @@
-import * as os from 'os'
-import { normalizeAbsolutePath } from '../utils'
 import { toRollupPlugin } from '../rollup'
-import { UnpluginInstance, UnpluginFactory, UnpluginContextMeta } from '../types'
+import { UnpluginInstance, UnpluginFactory, VitePlugin, UnpluginContextMeta } from '../types'
 
 export function getVitePlugin <UserOptions = {}> (
   factory: UnpluginFactory<UserOptions>
@@ -10,41 +8,13 @@ export function getVitePlugin <UserOptions = {}> (
     const meta: UnpluginContextMeta = {
       framework: 'vite'
     }
-
     const rawPlugin = factory(userOptions, meta)
 
-    // On windows, Vite replaces backward slashes in paths/ids with forward slashes
-    // in the `load`, `transformInclude`, and `transform` hooks. The `resolveId` hook
-    // however has backwards slashes.
-    // To ensure consistent ids across all hooks, we replace the forward slashes
-    // in the `load`, `transformInclude`, and `transform` hooks with backward slashes
-    if (os.platform() === 'win32') {
-      if (rawPlugin.load) {
-        const _load = rawPlugin.load
-        rawPlugin.load = function (id, ...args) {
-          return _load.call(this, normalizeAbsolutePath(id), ...args)
-        }
-      }
-      if (rawPlugin.transformInclude) {
-        const _transformInclude = rawPlugin.transformInclude
-        rawPlugin.transformInclude = function (id, ...args) {
-          return _transformInclude.call(this, normalizeAbsolutePath(id), ...args)
-        }
-      }
-      if (rawPlugin.transform) {
-        const _transform = rawPlugin.transform
-        rawPlugin.transform = function (code, id, ...args) {
-          return _transform.call(this, code, normalizeAbsolutePath(id), ...args)
-        }
-      }
-    }
-
-    const plugin = toRollupPlugin(rawPlugin, false)
+    const plugin = toRollupPlugin(rawPlugin, false) as VitePlugin
 
     if (rawPlugin.vite) {
       Object.assign(plugin, rawPlugin.vite)
     }
-
     return plugin
   }
 }

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -8,8 +8,16 @@ import { slash, backSlash } from './utils'
 import { createContext } from './context'
 
 const _dirname = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
-const TRANSFORM_LOADER = resolve(_dirname, 'webpack/loaders/transform.js')
-const LOAD_LOADER = resolve(_dirname, 'webpack/loaders/load.js')
+
+const TRANSFORM_LOADER = resolve(
+  _dirname,
+  __BUNDLED__ ? 'webpack/loaders/transform' : '../../dist/webpack/loaders/transform'
+)
+
+const LOAD_LOADER = resolve(
+  _dirname,
+  __BUNDLED__ ? 'webpack/loaders/load' : '../../dist/webpack/loaders/load'
+)
 
 export function getWebpackPlugin<UserOptions = {}> (
   factory: UnpluginFactory<UserOptions>
@@ -141,10 +149,10 @@ export function getWebpackPlugin<UserOptions = {}> (
         }
 
         // load hook
-        if (plugin.load && plugin.__vfsModules) {
+        if (plugin.load) {
           compiler.options.module.rules.push({
-            include (id) {
-              return id != null && plugin.__vfsModules!.has(id)
+            include () {
+              return true
             },
             enforce: plugin.enforce,
             use: [{

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -11,12 +11,12 @@ const _dirname = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLT
 
 const TRANSFORM_LOADER = resolve(
   _dirname,
-  __BUNDLED__ ? 'webpack/loaders/transform' : '../../dist/webpack/loaders/transform'
+  __DEV__ ? '../../dist/webpack/loaders/transform' : 'webpack/loaders/transform'
 )
 
 const LOAD_LOADER = resolve(
   _dirname,
-  __BUNDLED__ ? 'webpack/loaders/load' : '../../dist/webpack/loaders/load'
+  __DEV__ ? '../../dist/webpack/loaders/load' : 'webpack/loaders/load'
 )
 
 // We need the prefix of virtual modules to be an absolute path so webpack let's us load them (even if it's made up)

--- a/src/webpack/loaders/load.ts
+++ b/src/webpack/loaders/load.ts
@@ -1,7 +1,7 @@
 import type { LoaderContext } from 'webpack'
 import { UnpluginContext } from '../../types'
 import { createContext } from '../context'
-import { slash } from '../utils'
+import { normalizeAbsolutePath } from '../../utils'
 
 export default async function load (this: LoaderContext<any>, source: string, map: any) {
   const callback = this.async()
@@ -19,10 +19,13 @@ export default async function load (this: LoaderContext<any>, source: string, ma
   }
 
   if (id.startsWith(plugin.__virtualModulePrefix)) {
-    id = id.slice(plugin.__virtualModulePrefix.length)
+    id = decodeURIComponent(id.slice(plugin.__virtualModulePrefix.length))
   }
 
-  const res = await plugin.load.call(Object.assign(this._compilation && createContext(this._compilation) as any, context), slash(id))
+  const res = await plugin.load.call(
+    Object.assign(this._compilation && createContext(this._compilation) as any, context),
+    normalizeAbsolutePath(id)
+  )
 
   if (res == null) {
     callback(null, source, map)

--- a/src/webpack/utils.ts
+++ b/src/webpack/utils.ts
@@ -1,9 +1,0 @@
-import { sep } from 'path'
-
-export function slash (path: string) {
-  return path.replace(/\\/g, '/')
-}
-
-export function backSlash (path: string) {
-  return path.replace(/[\\/]/g, sep)
-}

--- a/test/unit-tests/id-consistency/id-consistency.test.ts
+++ b/test/unit-tests/id-consistency/id-consistency.test.ts
@@ -131,7 +131,8 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
           entry: entryFilePath,
           plugins: [plugin()],
           externals: ['path'],
-          mode: 'production'
+          mode: 'production',
+          target: 'node' // needed for webpack 4 so it doesn't try to "browserify" any node externals and load addtional modules
         },
         () => {
           resolve()

--- a/test/unit-tests/id-consistency/id-consistency.test.ts
+++ b/test/unit-tests/id-consistency/id-consistency.test.ts
@@ -27,7 +27,7 @@ function createUnpluginWithCallback (
 }
 
 // We extract this check because all bundlers should behave the same
-function checkResolveIdHook (
+function checkHookCalls (
   resolveIdCallback: Mock,
   transformIncludeCallback: Mock,
   transformCallback: Mock,
@@ -91,7 +91,7 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
       }
     })
 
-    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+    checkHookCalls(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
   })
 
   it('rollup', async () => {
@@ -113,7 +113,7 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
       external: ['path']
     })
 
-    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+    checkHookCalls(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
   })
 
   it('webpack', async () => {
@@ -143,7 +143,7 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
       )
     })
 
-    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+    checkHookCalls(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
   })
 
   it('esbuild', async () => {
@@ -167,6 +167,6 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
       external: ['path']
     })
 
-    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+    checkHookCalls(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
   })
 })

--- a/test/unit-tests/id-consistency/id-consistency.test.ts
+++ b/test/unit-tests/id-consistency/id-consistency.test.ts
@@ -1,10 +1,7 @@
 import * as path from 'path'
 import { it, describe, expect, vi, afterEach, Mock } from 'vitest'
-import * as vite from 'vite'
-import * as rollup from 'rollup'
-import { webpack } from 'webpack'
-import * as esbuild from 'esbuild'
 import { createUnplugin, UnpluginOptions } from '../../../src'
+import { build } from '../utils'
 
 const entryFilePath = path.resolve(__dirname, './test-src/entry.js')
 
@@ -75,7 +72,7 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
       mockLoadHook
     ).vite
 
-    await vite.build({
+    await build.vite({
       clearScreen: false,
       plugins: [{ ...plugin(), enforce: 'pre' }], // we need to define `enforce` here for the plugin to be run
       build: {
@@ -106,7 +103,7 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
       mockLoadHook
     ).rollup
 
-    await rollup.rollup({
+    await build.rollup({
       input: entryFilePath,
       plugins: [plugin()],
       external: ['path']
@@ -129,7 +126,7 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
     ).webpack
 
     await new Promise<void>((resolve) => {
-      webpack(
+      build.webpack(
         {
           entry: entryFilePath,
           plugins: [plugin()],
@@ -158,7 +155,7 @@ describe('id parameter should be consistent accross hooks and plugins', () => {
       mockLoadHook
     ).esbuild
 
-    await esbuild.build({
+    await build.esbuild({
       entryPoints: [entryFilePath],
       plugins: [plugin()],
       bundle: true, // actually traverse imports

--- a/test/unit-tests/id-consistency/id-consistency.test.ts
+++ b/test/unit-tests/id-consistency/id-consistency.test.ts
@@ -1,0 +1,172 @@
+import * as path from 'path'
+import { it, describe, expect, vi, afterEach, Mock } from 'vitest'
+import * as vite from 'vite'
+import * as rollup from 'rollup'
+import { webpack } from 'webpack'
+import * as esbuild from 'esbuild'
+import { createUnplugin, UnpluginOptions } from '../../../src'
+
+const entryFilePath = path.resolve(__dirname, './test-src/entry.js')
+const proxyExportFilePath = path.resolve(__dirname, './test-src/proxy-export.js')
+const defaultExportFilePath = path.resolve(__dirname, './test-src/default-export.js')
+const namedExportFilePath = path.resolve(__dirname, './test-src/sub-folder/named-export.js')
+
+function createUnpluginWithCallback (
+  resolveIdCallback: UnpluginOptions['resolveId'],
+  transformIncludeCallback: UnpluginOptions['transformInclude'],
+  transformCallback: UnpluginOptions['transform'],
+  loadCallback: UnpluginOptions['load']
+) {
+  return createUnplugin(() => ({
+    name: 'test-plugin',
+    resolveId: resolveIdCallback,
+    transformInclude: transformIncludeCallback,
+    transform: transformCallback,
+    load: loadCallback
+  }))
+}
+
+// We extract this check because all bundlers should behave the same
+function checkResolveIdHook (
+  resolveIdCallback: Mock,
+  transformIncludeCallback: Mock,
+  transformCallback: Mock,
+  loadCallback: Mock
+): void {
+  expect(resolveIdCallback).toHaveBeenCalledTimes(4)
+  expect(resolveIdCallback).toHaveBeenCalledWith(entryFilePath, undefined, expect.anything())
+  expect(resolveIdCallback).toHaveBeenCalledWith('./proxy-export', expect.anything(), expect.anything())
+  expect(resolveIdCallback).toHaveBeenCalledWith('./sub-folder/named-export', expect.anything(), expect.anything())
+  expect(resolveIdCallback).toHaveBeenCalledWith('./default-export', expect.anything(), expect.anything())
+
+  expect(transformIncludeCallback).toHaveBeenCalledTimes(4)
+  expect(transformIncludeCallback).toHaveBeenCalledWith(entryFilePath)
+  expect(transformIncludeCallback).toHaveBeenCalledWith(proxyExportFilePath)
+  expect(transformIncludeCallback).toHaveBeenCalledWith(namedExportFilePath)
+  expect(transformIncludeCallback).toHaveBeenCalledWith(defaultExportFilePath)
+
+  expect(transformCallback).toHaveBeenCalledTimes(4)
+  expect(transformCallback).toHaveBeenCalledWith(expect.anything(), entryFilePath)
+  expect(transformCallback).toHaveBeenCalledWith(expect.anything(), proxyExportFilePath)
+  expect(transformCallback).toHaveBeenCalledWith(expect.anything(), namedExportFilePath)
+  expect(transformCallback).toHaveBeenCalledWith(expect.anything(), defaultExportFilePath)
+
+  expect(loadCallback).toHaveBeenCalledTimes(4)
+  expect(loadCallback).toHaveBeenCalledWith(entryFilePath)
+  expect(loadCallback).toHaveBeenCalledWith(proxyExportFilePath)
+  expect(loadCallback).toHaveBeenCalledWith(namedExportFilePath)
+  expect(loadCallback).toHaveBeenCalledWith(defaultExportFilePath)
+}
+
+describe('id parameter should be consistent accross hooks and plugins', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('vite', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const mockTransformIncludeHook = vi.fn(() => true)
+    const mockTransformHook = vi.fn(() => undefined)
+    const mockLoadHook = vi.fn(() => undefined)
+
+    const plugin = createUnpluginWithCallback(
+      mockResolveIdHook,
+      mockTransformIncludeHook,
+      mockTransformHook,
+      mockLoadHook
+    ).vite
+
+    await vite.build({
+      clearScreen: false,
+      plugins: [{ ...plugin(), enforce: 'pre' }], // we need to define `enforce` here for the plugin to be run
+      build: {
+        lib: {
+          entry: path.resolve(__dirname, 'test-src/entry.js'),
+          name: 'TestLib'
+        },
+        rollupOptions: {
+          external: ['path']
+        },
+        write: false // don't output anything
+      }
+    })
+
+    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+  })
+
+  it('rollup', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const mockTransformIncludeHook = vi.fn(() => true)
+    const mockTransformHook = vi.fn(() => undefined)
+    const mockLoadHook = vi.fn(() => undefined)
+
+    const plugin = createUnpluginWithCallback(
+      mockResolveIdHook,
+      mockTransformIncludeHook,
+      mockTransformHook,
+      mockLoadHook
+    ).rollup
+
+    await rollup.rollup({
+      input: path.resolve(__dirname, 'test-src/entry.js'),
+      plugins: [plugin()],
+      external: ['path']
+    })
+
+    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+  })
+
+  it('webpack', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const mockTransformIncludeHook = vi.fn(() => true)
+    const mockTransformHook = vi.fn(() => undefined)
+    const mockLoadHook = vi.fn(() => undefined)
+
+    const plugin = createUnpluginWithCallback(
+      mockResolveIdHook,
+      mockTransformIncludeHook,
+      mockTransformHook,
+      mockLoadHook
+    ).webpack
+
+    await new Promise<void>((resolve) => {
+      webpack(
+        {
+          entry: path.resolve(__dirname, 'test-src/entry.js'),
+          plugins: [plugin()],
+          externals: ['path'],
+          mode: 'production'
+        },
+        () => {
+          resolve()
+        }
+      )
+    })
+
+    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+  })
+
+  it('esbuild', async () => {
+    const mockResolveIdHook = vi.fn(() => undefined)
+    const mockTransformIncludeHook = vi.fn(() => true)
+    const mockTransformHook = vi.fn(() => undefined)
+    const mockLoadHook = vi.fn(() => undefined)
+
+    const plugin = createUnpluginWithCallback(
+      mockResolveIdHook,
+      mockTransformIncludeHook,
+      mockTransformHook,
+      mockLoadHook
+    ).esbuild
+
+    await esbuild.build({
+      entryPoints: [path.resolve(__dirname, 'test-src/entry.js')],
+      plugins: [plugin()],
+      bundle: true, // actually traverse imports
+      write: false, // don't pollute console
+      external: ['path']
+    })
+
+    checkResolveIdHook(mockResolveIdHook, mockTransformIncludeHook, mockTransformHook, mockLoadHook)
+  })
+})

--- a/test/unit-tests/id-consistency/test-src/default-export.js
+++ b/test/unit-tests/id-consistency/test-src/default-export.js
@@ -1,0 +1,1 @@
+export default 'some string'

--- a/test/unit-tests/id-consistency/test-src/entry.js
+++ b/test/unit-tests/id-consistency/test-src/entry.js
@@ -1,0 +1,9 @@
+import * as path from 'path' // test external modules
+import { named, proxiedDefault } from './proxy-export'
+
+// just some random code to use the imports
+process.stdout.write(JSON.stringify({
+  named,
+  proxiedDefault,
+  path: path.join(__dirname, __filename)
+}))

--- a/test/unit-tests/id-consistency/test-src/proxy-export.js
+++ b/test/unit-tests/id-consistency/test-src/proxy-export.js
@@ -1,0 +1,2 @@
+export { named } from './sub-folder/named-export'
+export { default as proxiedDefault } from './default-export'

--- a/test/unit-tests/id-consistency/test-src/sub-folder/named-export.js
+++ b/test/unit-tests/id-consistency/test-src/sub-folder/named-export.js
@@ -1,0 +1,1 @@
+export const named = 'named export'

--- a/test/unit-tests/resolve-id-external/resolve-id-external.test.ts
+++ b/test/unit-tests/resolve-id-external/resolve-id-external.test.ts
@@ -83,7 +83,8 @@ describe('load hook should not be called when resolveId hook returned `external:
           entry: entryFilePath,
           plugins: [plugin()],
           externals: ['path'],
-          mode: 'production'
+          mode: 'production',
+          target: 'node' // needed for webpack 4 so it doesn't try to "browserify" any node externals and load addtional modules
         },
         () => {
           resolve()

--- a/test/unit-tests/resolve-id-external/resolve-id-external.test.ts
+++ b/test/unit-tests/resolve-id-external/resolve-id-external.test.ts
@@ -1,0 +1,113 @@
+import * as path from 'path'
+import { it, describe, expect, vi, afterEach } from 'vitest'
+import * as vite from 'vite'
+import * as rollup from 'rollup'
+import { webpack } from 'webpack'
+import * as esbuild from 'esbuild'
+import { createUnplugin } from '../../../src'
+
+const entryFilePath = path.resolve(__dirname, './test-src/entry.js')
+
+describe('load hook should not be called when resolveId hook returned `external: true`', () => {
+  const mockResolveIdHook = vi.fn((id: string) => {
+    if (id === 'external-module') {
+      return {
+        id,
+        external: true
+      }
+    } else {
+      return null
+    }
+  })
+  const mockLoadHook = vi.fn(() => undefined)
+
+  function createMockedUnplugin () {
+    return createUnplugin(() => ({
+      name: 'test-plugin',
+      resolveId: mockResolveIdHook,
+      load: mockLoadHook
+    }))
+  }
+  // We extract this check because all bundlers should behave the same
+  function checkHookCalls (): void {
+    expect(mockResolveIdHook).toHaveBeenCalledTimes(3)
+    expect(mockResolveIdHook).toHaveBeenCalledWith(entryFilePath, undefined, expect.anything())
+    expect(mockResolveIdHook).toHaveBeenCalledWith('./internal-module.js', expect.anything(), expect.anything())
+    expect(mockResolveIdHook).toHaveBeenCalledWith('external-module', expect.anything(), expect.anything())
+
+    expect(mockLoadHook).toHaveBeenCalledTimes(2)
+    expect(mockLoadHook).toHaveBeenCalledWith(expect.stringMatching(/(?:\/|\\)entry\.js$/))
+    expect(mockLoadHook).toHaveBeenCalledWith(expect.stringMatching(/(?:\/|\\)internal-module\.js$/))
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('vite', async () => {
+    const plugin = createMockedUnplugin().vite
+
+    await vite.build({
+      clearScreen: false,
+      plugins: [{ ...plugin(), enforce: 'pre' }], // we need to define `enforce` here for the plugin to be run
+      build: {
+        lib: {
+          entry: entryFilePath,
+          name: 'TestLib'
+        },
+        rollupOptions: {
+          external: ['path']
+        },
+        write: false // don't output anything
+      }
+    })
+
+    checkHookCalls()
+  })
+
+  it('rollup', async () => {
+    const plugin = createMockedUnplugin().rollup
+
+    await rollup.rollup({
+      input: entryFilePath,
+      plugins: [plugin()],
+      external: ['path']
+    })
+
+    checkHookCalls()
+  })
+
+  it('webpack', async () => {
+    const plugin = createMockedUnplugin().webpack
+
+    await new Promise<void>((resolve) => {
+      webpack(
+        {
+          entry: entryFilePath,
+          plugins: [plugin()],
+          externals: ['path'],
+          mode: 'production'
+        },
+        () => {
+          resolve()
+        }
+      )
+    })
+
+    checkHookCalls()
+  })
+
+  it('esbuild', async () => {
+    const plugin = createMockedUnplugin().esbuild
+
+    await esbuild.build({
+      entryPoints: [entryFilePath],
+      plugins: [plugin()],
+      bundle: true, // actually traverse imports
+      write: false, // don't pollute console
+      external: ['path']
+    })
+
+    checkHookCalls()
+  })
+})

--- a/test/unit-tests/resolve-id-external/resolve-id-external.test.ts
+++ b/test/unit-tests/resolve-id-external/resolve-id-external.test.ts
@@ -1,10 +1,7 @@
 import * as path from 'path'
 import { it, describe, expect, vi, afterEach } from 'vitest'
-import * as vite from 'vite'
-import * as rollup from 'rollup'
-import { webpack } from 'webpack'
-import * as esbuild from 'esbuild'
 import { createUnplugin } from '../../../src'
+import { build } from '../utils'
 
 const entryFilePath = path.resolve(__dirname, './test-src/entry.js')
 
@@ -47,7 +44,7 @@ describe('load hook should not be called when resolveId hook returned `external:
   it('vite', async () => {
     const plugin = createMockedUnplugin().vite
 
-    await vite.build({
+    await build.vite({
       clearScreen: false,
       plugins: [{ ...plugin(), enforce: 'pre' }], // we need to define `enforce` here for the plugin to be run
       build: {
@@ -68,7 +65,7 @@ describe('load hook should not be called when resolveId hook returned `external:
   it('rollup', async () => {
     const plugin = createMockedUnplugin().rollup
 
-    await rollup.rollup({
+    await build.rollup({
       input: entryFilePath,
       plugins: [plugin()],
       external: ['path']
@@ -81,7 +78,7 @@ describe('load hook should not be called when resolveId hook returned `external:
     const plugin = createMockedUnplugin().webpack
 
     await new Promise<void>((resolve) => {
-      webpack(
+      build.webpack(
         {
           entry: entryFilePath,
           plugins: [plugin()],
@@ -100,7 +97,7 @@ describe('load hook should not be called when resolveId hook returned `external:
   it('esbuild', async () => {
     const plugin = createMockedUnplugin().esbuild
 
-    await esbuild.build({
+    await build.esbuild({
       entryPoints: [entryFilePath],
       plugins: [plugin()],
       bundle: true, // actually traverse imports

--- a/test/unit-tests/resolve-id-external/test-src/entry.js
+++ b/test/unit-tests/resolve-id-external/test-src/entry.js
@@ -1,0 +1,8 @@
+import external from 'external-module'
+import internal from './internal-module.js'
+
+// just some random code to use the imports
+process.stdout.write(JSON.stringify({
+  internal,
+  external
+}))

--- a/test/unit-tests/resolve-id-external/test-src/internal-module.js
+++ b/test/unit-tests/resolve-id-external/test-src/internal-module.js
@@ -1,0 +1,1 @@
+export default 'some-internal-module'

--- a/test/unit-tests/resolve-id/resolve-id.test.ts
+++ b/test/unit-tests/resolve-id/resolve-id.test.ts
@@ -1,10 +1,7 @@
 import * as path from 'path'
 import { it, describe, expect, vi, afterEach, Mock } from 'vitest'
-import * as vite from 'vite'
-import * as rollup from 'rollup'
-import * as webpack from 'webpack'
-import * as esbuild from 'esbuild'
 import { createUnplugin, UnpluginOptions } from '../../../src'
+import { build } from '../utils'
 
 function createUnpluginWithCallback (resolveIdCallback: UnpluginOptions['resolveId']) {
   return createUnplugin(() => ({
@@ -51,7 +48,7 @@ describe('resolveId hook', () => {
     const mockResolveIdHook = vi.fn(() => undefined)
     const plugin = createUnpluginWithCallback(mockResolveIdHook).vite
 
-    await vite.build({
+    await build.vite({
       clearScreen: false,
       plugins: [{ ...plugin(), enforce: 'pre' }], // we need to define `enforce` here for the plugin to be run
       build: {
@@ -70,7 +67,7 @@ describe('resolveId hook', () => {
     const mockResolveIdHook = vi.fn(() => undefined)
     const plugin = createUnpluginWithCallback(mockResolveIdHook).rollup
 
-    await rollup.rollup({
+    await build.rollup({
       input: path.resolve(__dirname, 'test-src/entry.js'),
       plugins: [plugin()]
     })
@@ -83,8 +80,7 @@ describe('resolveId hook', () => {
     const plugin = createUnpluginWithCallback(mockResolveIdHook).webpack
 
     await new Promise((resolve) => {
-      // @ts-ignore
-      (webpack.webpack || webpack.default || webpack)(
+      build.webpack(
         {
           entry: path.resolve(__dirname, 'test-src/entry.js'),
           plugins: [plugin()]
@@ -100,7 +96,7 @@ describe('resolveId hook', () => {
     const mockResolveIdHook = vi.fn(() => undefined)
     const plugin = createUnpluginWithCallback(mockResolveIdHook).esbuild
 
-    await esbuild.build({
+    await build.esbuild({
       entryPoints: [path.resolve(__dirname, 'test-src/entry.js')],
       plugins: [plugin()],
       bundle: true, // actually traverse imports

--- a/test/unit-tests/utils.ts
+++ b/test/unit-tests/utils.ts
@@ -1,0 +1,16 @@
+import * as vite from 'vite'
+import * as rollup from 'rollup'
+import * as webpack from 'webpack'
+import * as esbuild from 'esbuild'
+
+export const viteBuild = vite.build
+export const rollupBuild = rollup.rollup
+export const esbuildBuild = esbuild.build
+export const webpackBuild = (webpack.webpack || (webpack as any).default || webpack) as typeof webpack.webpack
+
+export const build = {
+  webpack: webpackBuild,
+  rollup: rollupBuild,
+  vite: viteBuild,
+  esbuild: esbuildBuild
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,6 @@ export const tsup: Options = {
     'src/webpack/loaders/transform.ts'
   ],
   define: {
-    __BUNDLED__: 'true'
+    __DEV__: 'false'
   }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,5 +11,8 @@ export const tsup: Options = {
     'src/index.ts',
     'src/webpack/loaders/load.ts',
     'src/webpack/loaders/transform.ts'
-  ]
+  ],
+  define: {
+    __BUNDLED__: 'true'
+  }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  define: {
+    __BUNDLED__: 'false' // during tests, the library isn't being run in bundled form
+  }
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   define: {
-    __BUNDLED__: 'false' // during tests, the library isn't being run in bundled form
+    __DEV__: 'true'
   }
 })


### PR DESCRIPTION
This PR fixes a behavior where the passed `id` args aren't the same across bundlers and hook calls. It also adds tests to ensure this behavior.

In detail:
- Don't run the `resolveId` hook in esbuild when the module is marked as external. (mirrors rollup's behavior)
- Run `load` for all loaded modules in webpack. I don't actually know if this change is problematic. I would love some insight into why the check for virtual modules was introduced in the first place.
- Introduce a build-time flag, since webpack loaders and unit tests are a bit tricky with path resolution.
- Replace the slash/backslash utilities with a more sustainable solution that always normalizes absolute paths/ids to OS conform paths
- URL encode the module id in webpack before passing it to loader (avoids path shenanigans)