### PR TITLE
fix(webpack): avoid repeat set __vfsModules value

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -134,8 +134,10 @@ export function getWebpackPlugin<UserOptions = {}> (
                     )
 
                     // webpack virtual module should pass in the correct path
-                    plugin.__vfs!.writeModule(resolved, '')
-                    plugin.__vfsModules!.add(resolved)
+                    if (!plugin.__vfsModules!.has(resolved)) {
+                      plugin.__vfs!.writeModule(resolved, '')
+                      plugin.__vfsModules!.add(resolved)
+                    }
                   }
 
                   // construct the new request

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -134,6 +134,7 @@ export function getWebpackPlugin<UserOptions = {}> (
                     )
 
                     // webpack virtual module should pass in the correct path
+                    // https://github.com/unjs/unplugin/pull/155
                     if (!plugin.__vfsModules!.has(resolved)) {
                       plugin.__vfs!.writeModule(resolved, '')
                       plugin.__vfsModules!.add(resolved)


### PR DESCRIPTION
fix: https://github.com/unocss/unocss/issues/1429

Actually, I don't know why there didn't have this problem(infinite compile) before. But by my test, do not repeat reset `__vfsModules` value is works.