### PR TITLE
docs: add create-unplugin to starter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ export const unplugin = createUnplugin((options: UserOptions, meta) => {
 ## Starter Templates
 
 - [unplugin-starter](https://github.com/antfu/unplugin-starter)
-- [create-unplugin](https://github.com/jwr12135/create-unplugin)
+- [create-unplugin](https://github.com/jwr12135/create-unplugin) <sup><code>Community</code></sup>
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ export const unplugin = createUnplugin((options: UserOptions, meta) => {
 ## Starter Templates
 
 - [unplugin-starter](https://github.com/antfu/unplugin-starter)
+- [create-unplugin](https://github.com/jwr12135/create-unplugin)
 
 ## Examples
 


### PR DESCRIPTION
This package is meant to make creating an unplugin even easier. You execute the command and follow the prompts to customize the generated project. Any suggestions from @antfu or anyone else for improvements would be appreciated. I want to make this one of the easiest ways to get started with unplugin.