### PR TITLE
docs: add a community showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ export const unplugin = createUnplugin((options: UserOptions, meta) => {
 - [unplugin-ast](https://github.com/sxzz/unplugin-ast)
 - [unplugin-element-plus](https://github.com/element-plus/unplugin-element-plus)
 - [unplugin-glob](https://github.com/sxzz/unplugin-glob)
+- [unplugin-sentry](https://github.com/kricsleo/unplugin-sentry)
 
 ## License
 


### PR DESCRIPTION
[`unplugin-sentry`](https://github.com/kricsleo/unplugin-sentry) is an all-in-one plugin(based on `unplugin`) for projects to work with [Sentry](https://docs.sentry.io/). Hopes to add it to the community showcases. Any question is welcome!