### PR TITLE
refactor: watch logic to improve readability

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -73,25 +73,23 @@ export function getEsbuildPlugin<UserOptions = {}>(
               await plugin.writeBundle()
 
             if (initialOptions.watch) {
-              Object.keys(watchListRecord).forEach((id) => {
+              for (const id of watchList.keys()) {
                 if (!watchList.has(id)) {
-                  watchListRecord[id].close()
+                  await watchListRecord[id].close()
                   delete watchListRecord[id]
                 }
-              })
-              watchList.forEach((id) => {
-                if (!Object.keys(watchListRecord).includes(id)) {
+                else if (!watchListRecord[id]) {
                   watchListRecord[id] = chokidar.watch(id)
                   watchListRecord[id].on('change', async () => {
                     await plugin.watchChange?.call(context, id, { event: 'update' })
-                    rebuild()
+                    await rebuild()
                   })
                   watchListRecord[id].on('unlink', async () => {
                     await plugin.watchChange?.call(context, id, { event: 'delete' })
-                    rebuild()
+                    await rebuild()
                   })
                 }
-              })
+              }
             }
           })
         }


### PR DESCRIPTION
Refactored the if statement in the onEnd callback function to replace the use of Object.keys and forEach with a simple if statement to improve code readability. The code now checks if the watchListRecord has the id of each item in the watchList, and closes and deletes any record that is not present in the watchList. Then, for each id in the watchList, the code checks if it is already present in the watchListRecord, and if not, creates a new record and sets up the event listeners for the change and unlink events. Overall, this refactor simplifies the code and makes it easier to read and understand.