### PR TITLE
feat: add top-level functions to create platform-specific plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,27 @@ export const unplugin = createUnplugin((options: UserOptions, meta) => {
 })
 ```
 
+### Creating platform specific plugins
+
+The package exports a set of functions in place of `createUnplugin` that allow for the creation of plugins for specific bundlers.
+Each of the function takes the same generic factory argument as `createUnplugin`.
+
+```ts
+import {
+  getVitePlugin,
+  getRollupPlugin,
+  getWebpackPlugin,
+  creteEsbuildPlugin,
+  getRspackPlugin
+} from "unplugin";
+
+const vitePlugin = getVitePlugin({ /* options */ });
+const rollupPlugin = getRollupPlugin({ /* options */ });
+const esbuildPlugin = creteEsbuildPlugin({ /* options */ });
+const webpackPlugin = getWebpackPlugin({ /* options */ });
+const rspackPlugin = getRspackPlugin({ /* options */ });
+```
+
 ## Conventions
 
 - Plugins powered by unplugin should have a clear name with `unplugin-` prefix.

--- a/README.md
+++ b/README.md
@@ -232,18 +232,18 @@ Each of the function takes the same generic factory argument as `createUnplugin`
 
 ```ts
 import {
-  getVitePlugin,
-  getRollupPlugin,
-  getWebpackPlugin,
   creteEsbuildPlugin,
-  getRspackPlugin
-} from "unplugin";
+  getRollupPlugin,
+  getRspackPlugin,
+  getVitePlugin,
+  getWebpackPlugin
+} from 'unplugin'
 
-const vitePlugin = getVitePlugin({ /* options */ });
-const rollupPlugin = getRollupPlugin({ /* options */ });
-const esbuildPlugin = creteEsbuildPlugin({ /* options */ });
-const webpackPlugin = getWebpackPlugin({ /* options */ });
-const rspackPlugin = getRspackPlugin({ /* options */ });
+const vitePlugin = getVitePlugin({ /* options */ })
+const rollupPlugin = getRollupPlugin({ /* options */ })
+const esbuildPlugin = creteEsbuildPlugin({ /* options */ })
+const webpackPlugin = getWebpackPlugin({ /* options */ })
+const rspackPlugin = getRspackPlugin({ /* options */ })
 ```
 
 ## Conventions

--- a/src/define.ts
+++ b/src/define.ts
@@ -30,3 +30,33 @@ export function createUnplugin<UserOptions, Nested extends boolean = boolean>(
     },
   }
 }
+
+export function creteEsbuildPlugin<UserOptions, Nested extends boolean = boolean>(
+  factory: UnpluginFactory<UserOptions, Nested>,
+) {
+  return getEsbuildPlugin(factory)
+}
+
+export function creteRollupPlugin<UserOptions, Nested extends boolean = boolean>(
+  factory: UnpluginFactory<UserOptions, Nested>,
+) {
+  return getRollupPlugin(factory)
+}
+
+export function creteVitePlugin<UserOptions, Nested extends boolean = boolean>(
+  factory: UnpluginFactory<UserOptions, Nested>,
+) {
+  return getVitePlugin(factory)
+}
+
+export function creteWebpackPlugin<UserOptions, Nested extends boolean = boolean>(
+  factory: UnpluginFactory<UserOptions, Nested>,
+) {
+  return getWebpackPlugin(factory)
+}
+
+export function creteRspackPlugin<UserOptions, Nested extends boolean = boolean>(
+  factory: UnpluginFactory<UserOptions, Nested>,
+) {
+  return getRspackPlugin(factory)
+}


### PR DESCRIPTION
The current `createUnplugin` will not allow you to tree-shake unused code if you want to distribute individual plugins for each platform. I.e. the output may still contain webpack code even though you just want to create a rollup plugin.

This PR adds top-level methods to create plugins for the individual bundlers that are tree-shakable if unused.