### PR TITLE
fix: adjust webpack rspack hooks sequence

### DIFF
--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -32,13 +32,13 @@ export function getRspackPlugin<UserOptions = {}>(
         }
         const rawPlugins = toArray(factory(userOptions!, meta))
         for (const plugin of rawPlugins) {
-          // transform hook
-          if (plugin.transform) {
+       
+          // load hook
+          if (plugin.load) {
             const use: RuleSetUseItem = {
-              loader: TRANSFORM_LOADER,
+              loader: LOAD_LOADER,
               options: { plugin },
             }
-
             compiler.options.module.rules.unshift({
               enforce: plugin.enforce,
               include: /.*/,
@@ -46,12 +46,13 @@ export function getRspackPlugin<UserOptions = {}>(
             })
           }
 
-          // load hook
-          if (plugin.load) {
+          // transform hook
+          if (plugin.transform) {
             const use: RuleSetUseItem = {
-              loader: LOAD_LOADER,
+              loader: TRANSFORM_LOADER,
               options: { plugin },
             }
+
             compiler.options.module.rules.unshift({
               enforce: plugin.enforce,
               include: /.*/,

--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -32,7 +32,6 @@ export function getRspackPlugin<UserOptions = {}>(
         }
         const rawPlugins = toArray(factory(userOptions!, meta))
         for (const plugin of rawPlugins) {
-       
           // load hook
           if (plugin.load) {
             const use: RuleSetUseItem = {

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -57,27 +57,6 @@ export function getWebpackPlugin<UserOptions = {}>(
 
           const externalModules = new Set<string>()
 
-          // transform hook
-          if (plugin.transform) {
-            const useLoader: RuleSetUseItem[] = [{
-              loader: `${TRANSFORM_LOADER}?unpluginName=${encodeURIComponent(plugin.name)}`,
-            }]
-            const useNone: RuleSetUseItem[] = []
-            compiler.options.module.rules.unshift({
-              enforce: plugin.enforce,
-              use: (data: { resource: string | null; resourceQuery: string }) => {
-                if (data.resource == null)
-                  return useNone
-
-                const id = normalizeAbsolutePath(data.resource + (data.resourceQuery || ''))
-                if (!plugin.transformInclude || plugin.transformInclude(id))
-                  return useLoader
-
-                return useNone
-              },
-            })
-          }
-
           // resolveId hook
           if (plugin.resolveId) {
             let vfs = compiler.options.plugins.find(i => i instanceof VirtualModulesPlugin) as VirtualModulesPlugin
@@ -173,6 +152,27 @@ export function getWebpackPlugin<UserOptions = {}>(
                   unpluginName: plugin.name,
                 },
               }],
+            })
+          }
+
+          // transform hook
+          if (plugin.transform) {
+            const useLoader: RuleSetUseItem[] = [{
+              loader: `${TRANSFORM_LOADER}?unpluginName=${encodeURIComponent(plugin.name)}`,
+            }]
+            const useNone: RuleSetUseItem[] = []
+            compiler.options.module.rules.unshift({
+              enforce: plugin.enforce,
+              use: (data: { resource: string | null; resourceQuery: string }) => {
+                if (data.resource == null)
+                  return useNone
+
+                const id = normalizeAbsolutePath(data.resource + (data.resourceQuery || ''))
+                if (!plugin.transformInclude || plugin.transformInclude(id))
+                  return useLoader
+
+                return useNone
+              },
             })
           }
 

--- a/test/fixtures/load/__test__/build.test.ts
+++ b/test/fixtures/load/__test__/build.test.ts
@@ -7,33 +7,29 @@ const r = (...args: string[]) => resolve(__dirname, '../dist', ...args)
 describe('load-called-before-transform', () => {
   it('vite', async () => {
     const content = await fs.readFile(r('vite/main.js.mjs'), 'utf-8')
-    expect(content).toContain('load:VIRTUAL:ONE->transform-[Injected Vite]')
+    expect(content).toContain('it is a msg -> through the load hook -> transform-[Injected Vite]')
   })
 
   it('rollup', async () => {
     const content = await fs.readFile(r('rollup/main.js'), 'utf-8')
 
-    expect(content).toContain('load:VIRTUAL:ONE->transform-[Injected Rollup]')
+    expect(content).toContain('it is a msg -> through the load hook -> transform-[Injected Rollup]')
   })
 
   it('webpack', async () => {
     const content = await fs.readFile(r('webpack/main.js'), 'utf-8')
 
-    expect(content).toContain('load:VIRTUAL:ONE->transform-[Injected Webpack]')
+    expect(content).toContain('it is a msg -> through the load hook -> transform-[Injected Webpack]')
   })
 
-  // TODO: esbuild not yet support nested transform
-  it.fails('esbuild', async () => {
+  it('esbuild', async () => {
     const content = await fs.readFile(r('esbuild/main.js'), 'utf-8')
-
-    expect(content).toContain('NON-TARGET: __UNPLUGIN__')
+    expect(content).toContain('it is a msg -> through the load hook -> transform-[Injected Esbuild]')
   })
 
-  // it.skipIf(process.env.SKIP_RSPACK === 'true')('rspack', async () => {
-  //   const content = await fs.readFile(r('rspack/main.js'), 'utf-8')
+  it.skipIf(process.env.SKIP_RSPACK === 'true')('rspack', async () => {
+    const content = await fs.readFile(r('rspack/main.js'), 'utf-8')
 
-  //   expect(content).toContain('NON-TARGET: __UNPLUGIN__')
-  //   expect(content).toContain('TARGET: [Injected Post Rspack]')
-  //   expect(content).toContain('QUERY: [Injected Post Rspack]')
-  // })
+    expect(content).toContain('it is a msg -> through the load hook -> transform-[Injected Rspack]')
+  })
 })

--- a/test/fixtures/load/__test__/build.test.ts
+++ b/test/fixtures/load/__test__/build.test.ts
@@ -1,0 +1,39 @@
+import { resolve } from 'path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+
+const r = (...args: string[]) => resolve(__dirname, '../dist', ...args)
+
+describe('load-called-before-transform', () => {
+  it('vite', async () => {
+    const content = await fs.readFile(r('vite/main.js.mjs'), 'utf-8')
+    expect(content).toContain('load:VIRTUAL:ONE->transform-[Injected Vite]')
+  })
+
+  it('rollup', async () => {
+    const content = await fs.readFile(r('rollup/main.js'), 'utf-8')
+
+    expect(content).toContain('load:VIRTUAL:ONE->transform-[Injected Rollup]')
+  })
+
+  it('webpack', async () => {
+    const content = await fs.readFile(r('webpack/main.js'), 'utf-8')
+
+    expect(content).toContain('load:VIRTUAL:ONE->transform-[Injected Webpack]')
+  })
+
+  // TODO: esbuild not yet support nested transform
+  it.fails('esbuild', async () => {
+    const content = await fs.readFile(r('esbuild/main.js'), 'utf-8')
+
+    expect(content).toContain('NON-TARGET: __UNPLUGIN__')
+  })
+
+  // it.skipIf(process.env.SKIP_RSPACK === 'true')('rspack', async () => {
+  //   const content = await fs.readFile(r('rspack/main.js'), 'utf-8')
+
+  //   expect(content).toContain('NON-TARGET: __UNPLUGIN__')
+  //   expect(content).toContain('TARGET: [Injected Post Rspack]')
+  //   expect(content).toContain('QUERY: [Injected Post Rspack]')
+  // })
+})

--- a/test/fixtures/load/esbuild.config.js
+++ b/test/fixtures/load/esbuild.config.js
@@ -1,0 +1,12 @@
+const { build } = require('esbuild')
+const { esbuild } = require('./unplugin')
+
+build({
+  entryPoints: ['src/main.js'],
+  bundle: true,
+  outdir: 'dist/esbuild',
+  sourcemap: true,
+  plugins: [
+    esbuild({ msg: 'Esbuild' }),
+  ],
+})

--- a/test/fixtures/load/rollup.config.js
+++ b/test/fixtures/load/rollup.config.js
@@ -1,0 +1,12 @@
+const { rollup } = require('./unplugin')
+
+export default {
+  input: './src/main.js',
+  output: {
+    dir: './dist/rollup',
+    sourcemap: true,
+  },
+  plugins: [
+    rollup({ msg: 'Rollup' }),
+  ],
+}

--- a/test/fixtures/load/rspack.config.js
+++ b/test/fixtures/load/rspack.config.js
@@ -1,0 +1,14 @@
+const { resolve } = require('path')
+const { rspack } = require('./unplugin')
+
+/** @type import('@rspack/core').Configuration */
+module.exports = {
+  mode: 'development',
+  entry: resolve(__dirname, 'src/main.js'),
+  output: {
+    path: resolve(__dirname, 'dist/rspack'),
+    filename: 'main.js',
+  },
+  plugins: [rspack({ msg: 'Rspack' })],
+  devtool: 'source-map',
+}

--- a/test/fixtures/load/src/main.js
+++ b/test/fixtures/load/src/main.js
@@ -1,3 +1,3 @@
-import msg1 from 'virtual/1'
+import msg1 from './msg'
 
 console.log(msg1)

--- a/test/fixtures/load/src/main.js
+++ b/test/fixtures/load/src/main.js
@@ -1,0 +1,3 @@
+import msg1 from 'virtual/1'
+
+console.log(msg1)

--- a/test/fixtures/load/src/msg.js
+++ b/test/fixtures/load/src/msg.js
@@ -1,0 +1,1 @@
+export default 'it is a msg'

--- a/test/fixtures/load/unplugin.js
+++ b/test/fixtures/load/unplugin.js
@@ -1,0 +1,48 @@
+const MagicString = require('magic-string')
+const { createUnplugin } = require('unplugin')
+
+const virtualPath = 'virtual/1'
+
+function getVirtualId(id) {
+  // 规定虚拟模块需要返回 "\0"
+  return `\0${id}`
+}
+
+module.exports = createUnplugin((options) => {
+  return {
+    name: 'load-called-before-transform',
+    resolveId(id) {
+      if (id === virtualPath)
+        return getVirtualId(id)
+    },
+    loadInclude(id) {
+      return id === getVirtualId(virtualPath)
+    },
+    load() {
+      return 'export default "load:VIRTUAL:ONE__unplugin__"'
+    },
+    // transformInclude(id) {
+    //   return id === getVirtualId(virtualPath)
+    // },
+    transform(code, id) {
+      const s = new MagicString(code)
+      const index = code.indexOf('__unplugin__')
+      if (index === -1)
+        return null
+
+      const injectedCode = `->transform-[Injected ${options.msg}]`
+
+      if (code.includes(injectedCode))
+        throw new Error('File was already transformed')
+
+      s.overwrite(index, index + '__unplugin__'.length, injectedCode)
+      return {
+        code: s.toString(),
+        map: s.generateMap({
+          source: id,
+          includeContent: true,
+        }),
+      }
+    },
+  }
+})

--- a/test/fixtures/load/vite.config.js
+++ b/test/fixtures/load/vite.config.js
@@ -1,0 +1,18 @@
+const { resolve } = require('path')
+const { vite } = require('./unplugin')
+
+module.exports = {
+  root: __dirname,
+  plugins: [
+    vite({ msg: 'Vite' }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/main.js'),
+      name: 'main',
+      fileName: 'main.js',
+    },
+    outDir: 'dist/vite',
+    sourcemap: true,
+  },
+}

--- a/test/fixtures/load/webpack.config.js
+++ b/test/fixtures/load/webpack.config.js
@@ -1,0 +1,15 @@
+const { resolve } = require('path')
+const { webpack } = require('./unplugin')
+
+module.exports = {
+  mode: 'development',
+  entry: resolve(__dirname, 'src/main.js'),
+  output: {
+    path: resolve(__dirname, 'dist/webpack'),
+    filename: 'main.js',
+  },
+  plugins: [
+    webpack({ msg: 'Webpack' }),
+  ],
+  devtool: 'source-map',
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

webpack | Rspack, The load hook should be executed earlier than the transform hook

I'm not sure if I'm doing this as a Breaking change

![image](https://github.com/unjs/unplugin/assets/48666945/3c693c96-400f-46d4-8173-e0bb998de051)

[minimal reproduction](https://github.com/qiYuei/deef-webpack)



<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
