### PR TITLE
feat: esbuild config option to modify build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ export const unplugin = createUnplugin((options: UserOptions, meta) => {
       // from file extension (eg: .js -> "js", .jsx -> 'jsx')
       // loader?: (Loader | (code: string, id: string) => Loader)
 
+      // Read and/or modify build.initialOptions
+      // [https://esbuild.github.io/plugins/#build-options]
+      // config?: (initialOptions: BuildOptions) => void
+
       // Or you can completely replace the setup logic
       // setup?: EsbuildPlugin.setup,
     },

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -29,6 +29,9 @@ export function getEsbuildPlugin<UserOptions = Record<string, never>>(
 
         const context: UnpluginBuildContext = createEsbuildContext(initialOptions)
 
+        if (plugin.esbuild?.config)
+          plugin.esbuild.config.call(context, initialOptions)
+
         if (plugin.buildStart)
           onStart(() => plugin.buildStart!.call(context))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { AstNode, EmittedAsset, PluginContextMeta as RollupContextMeta, Plugin as RollupPlugin, SourceMapInput } from 'rollup'
 import type { Compiler as WebpackCompiler, WebpackPluginInstance } from 'webpack'
 import type { Plugin as VitePlugin } from 'vite'
-import type { Plugin as EsbuildPlugin, Loader, PluginBuild } from 'esbuild'
+import type { BuildOptions, Plugin as EsbuildPlugin, Loader, PluginBuild } from 'esbuild'
 import type { Compiler as RspackCompiler, RspackPluginInstance } from '@rspack/core'
 import type VirtualModulesPlugin from 'webpack-virtual-modules'
 
@@ -76,6 +76,7 @@ export interface UnpluginOptions {
     onLoadFilter?: RegExp
     setup?: EsbuildPlugin['setup']
     loader?: Loader | ((code: string, id: string) => Loader)
+    config?: (options: BuildOptions) => void
   }
 }
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite has a [`config` option](https://vitejs.dev/guide/api-plugin#config) that lets plugins view and/or modify the configuration.

I've been missing this option in esbuild. This PR adds a similar `config` option, which gets passed in [`build.initialOptions`](https://esbuild.github.io/plugins/#build-options).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
