### PR TITLE
fix: use webpack loader context to implement addWatchFile

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -5,7 +5,7 @@ import VirtualModulesPlugin from 'webpack-virtual-modules'
 import type { ResolvePluginInstance, Resolver } from 'webpack'
 import type { ResolvedUnpluginOptions, UnpluginContext, UnpluginContextMeta, UnpluginFactory, UnpluginInstance, WebpackCompiler } from '../types'
 import { normalizeAbsolutePath, shouldLoad, toArray, transformUse } from '../utils'
-import { createContext } from './context'
+import { contextOptionsFromCompilation, createContext } from './context'
 
 const TRANSFORM_LOADER = resolve(
   __dirname,
@@ -89,7 +89,18 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
                     const isEntry = requestContext.issuer === ''
 
                     // call hook
-                    const context = createContext()
+                    // resolveContext.fileDependencies is typed as a WriteOnlySet, so make our own copy here
+                    // so we can return it from getWatchFiles.
+                    const fileDependencies = new Set<string>()
+                    const context = createContext({
+                      addWatchFile(file) {
+                        fileDependencies.add(file)
+                        resolveContext.fileDependencies?.add(file)
+                      },
+                      getWatchFiles() {
+                        return Array.from(fileDependencies)
+                      },
+                    })
                     let error: Error | undefined
                     const pluginContext: UnpluginContext = {
                       error(msg: string | Error) {
@@ -178,7 +189,7 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
 
           if (plugin.watchChange || plugin.buildStart) {
             compiler.hooks.make.tapPromise(plugin.name, async (compilation) => {
-              const context = createContext(compilation)
+              const context = createContext(contextOptionsFromCompilation(compilation), compilation)
               if (plugin.watchChange && (compiler.modifiedFiles || compiler.removedFiles)) {
                 const promises: Promise<void>[] = []
                 if (compiler.modifiedFiles) {
@@ -201,7 +212,7 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
 
           if (plugin.buildEnd) {
             compiler.hooks.emit.tapPromise(plugin.name, async (compilation) => {
-              await plugin.buildEnd!.call(createContext(compilation))
+              await plugin.buildEnd!.call(createContext(contextOptionsFromCompilation(compilation), compilation))
             })
           }
 

--- a/src/webpack/loaders/load.ts
+++ b/src/webpack/loaders/load.ts
@@ -21,7 +21,14 @@ export default async function load(this: LoaderContext<any>, source: string, map
     id = decodeURIComponent(id.slice(plugin.__virtualModulePrefix.length))
 
   const res = await plugin.load.call(
-    { ...this._compilation && createContext(this._compilation) as any, ...context },
+    { ...createContext({
+      addWatchFile: (file) => {
+        this.addDependency(file)
+      },
+      getWatchFiles: () => {
+        return this.getDependencies()
+      },
+    }, this._compilation), ...context },
     normalizeAbsolutePath(id),
   )
 

--- a/src/webpack/loaders/transform.ts
+++ b/src/webpack/loaders/transform.ts
@@ -24,7 +24,14 @@ export default async function transform(this: LoaderContext<{ unpluginName: stri
     warn: error => this.emitWarning(typeof error === 'string' ? new Error(error) : error),
   }
   const res = await plugin.transform.call(
-    { ...this._compilation && createContext(this._compilation) as any, ...context },
+    { ...createContext({
+      addWatchFile: (file) => {
+        this.addDependency(file)
+      },
+      getWatchFiles: () => {
+        return this.getDependencies()
+      },
+    }, this._compilation), ...context },
     source,
     this.resource,
   )


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current implementation of `addWatchFile` in webpack uses the `compilation.fileDependencies`, which does result in the file being watched, but does not associate it with the current module being processed by a loader. As a result, webpack does not trigger recompilation of that module.

This PR fixes this by using the loader context's `addDependency` function, which both watches the file and adds it as a dependency of the module so it triggers recompilation. A similar API is used for resolvers as well.

Not sure if there is a way to unit test this: I didn't see any tests for watch behavior. However I did test this by npm linking into a project and using the `addWatchFile` in a webpack project.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
