### PR TITLE
fix: esbuild emitFile should mkdir subdirectories too

### DIFF
--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -126,13 +126,15 @@ export function createBuildContext(initialOptions: BuildOptions): UnpluginBuildC
       throw new Error('unplugin/esbuild: addWatchFile outside supported hooks (resolveId, load, transform)')
     },
     emitFile(emittedFile) {
-      // Ensure output directory exists for this.emitFile
-      if (initialOptions.outdir && !fs.existsSync(initialOptions.outdir))
-        fs.mkdirSync(initialOptions.outdir, { recursive: true })
-
       const outFileName = emittedFile.fileName || emittedFile.name
-      if (initialOptions.outdir && emittedFile.source && outFileName)
-        fs.writeFileSync(path.resolve(initialOptions.outdir, outFileName), emittedFile.source)
+      if (initialOptions.outdir && emittedFile.source && outFileName) {
+        const outPath = path.resolve(initialOptions.outdir, outFileName)
+        // Ensure output directory exists for this.emitFile
+        const outDir = path.dirname(outPath)
+        if (!fs.existsSync(outDir))
+          fs.mkdirSync(outDir, { recursive: true })
+        fs.writeFileSync(outPath, emittedFile.source)
+      }
     },
     getWatchFiles() {
       return watchFiles


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

n/a

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When calling `this.emitFile({fileName: 'subdir/foo.d.ts', source, type: 'asset'})`, Rollup [recursively makes the directory](https://github.com/rollup/rollup/blob/c9b3655ec25d08f5182feb3d118cc676940f1549/src/rollup/rollup.ts#L296) `dist/subdir` if necessary.

But unplugin's esbuild plugin does not; currently, it just makes the directory `dist` (where `dist` is the `outdir` option). If `dist/subdir` doesn't exit, the emit crashes.

This small PR changes the esbuild emitFile `mkdir` call to apply to the full directory (`dist/subdir` in the example, instead of `dist`).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
