### PR TITLE
fix(webpack,rspack): incorrect assumption about the current working directory in webpack and rspack

### DIFF
--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -19,14 +19,16 @@ const LOAD_LOADER = resolve(
   __DEV__ ? '../../dist/rspack/loaders/load.js' : 'rspack/loaders/load',
 )
 
-const VIRTUAL_MODULE_PREFIX = resolve(process.cwd(), '_virtual_')
-
 export function getRspackPlugin<UserOptions = Record<string, never>>(
   factory: UnpluginFactory<UserOptions>,
 ): UnpluginInstance<UserOptions>['rspack'] {
   return (userOptions?: UserOptions): RspackPluginInstance => {
     return {
       apply(compiler) {
+        // We need the prefix of virtual modules to be an absolute path so webpack let's us load them (even if it's made up)
+        // In the loader we strip the made up prefix path again
+        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), '_virtual_')
+
         const injected = compiler.$unpluginContext || {}
         compiler.$unpluginContext = injected
 

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -16,17 +16,17 @@ const LOAD_LOADER = resolve(
   __dirname,
   __DEV__ ? '../../dist/webpack/loaders/load' : 'webpack/loaders/load',
 )
-
-// We need the prefix of virtual modules to be an absolute path so webpack let's us load them (even if it's made up)
-// In the loader we strip the made up prefix path again
-const VIRTUAL_MODULE_PREFIX = resolve(process.cwd(), '_virtual_')
-
 export function getWebpackPlugin<UserOptions = Record<string, never>>(
   factory: UnpluginFactory<UserOptions>,
 ): UnpluginInstance<UserOptions>['webpack'] {
   return (userOptions?: UserOptions) => {
     return {
       apply(compiler: WebpackCompiler) {
+
+        // We need the prefix of virtual modules to be an absolute path so webpack let's us load them (even if it's made up)
+        // In the loader we strip the made up prefix path again
+        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), "_virtual_");
+
         const injected = compiler.$unpluginContext || {}
         compiler.$unpluginContext = injected
 

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -22,10 +22,9 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
   return (userOptions?: UserOptions) => {
     return {
       apply(compiler: WebpackCompiler) {
-
         // We need the prefix of virtual modules to be an absolute path so webpack let's us load them (even if it's made up)
         // In the loader we strip the made up prefix path again
-        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), "_virtual_");
+        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), '_virtual_')
 
         const injected = compiler.$unpluginContext || {}
         compiler.$unpluginContext = injected


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/unplugin/issues/375

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Build tools can decide to resolve from wherever they want, and it's not guaranteed that the place they resolve from is the user's current working directory. 

For example this reproduction of the failure case where in embroider (which uses a `node_modules/.embroider/` directory for the root -- and I imagine svelte apps, too with their `.svelte` directory)
https://github.com/embroider-build/embroider/issues/1843
Repro here: https://github.com/NullVoxPopuli/embroider-3--unplugin-plugin-loads-app-files

Here is a patched version of unplugin which allows the build to succeed: https://github.com/NullVoxPopuli/embroider-3--unplugin-plugin-loads-app-files/pull/1

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
