### PR TITLE
fix(esbuild): sourcemaps in transform result can be a string

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -284,8 +284,13 @@ function buildSetup(meta: UnpluginContextMeta & { framework: 'esbuild' }) {
               ]) as SourceMap
             }
             else {
-              // otherwise, we always keep the last one, even if it's empty
-              map = result.map as any
+              if (typeof result.map === 'string') {
+                map = JSON.parse(result.map)
+              }
+              else {
+                // otherwise, we always keep the last one, even if it's empty
+                map = result.map as SourceMap
+              }
             }
           }
 

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -279,7 +279,7 @@ function buildSetup(meta: UnpluginContextMeta & { framework: 'esbuild' }) {
             // combine the two sourcemaps
             if (map && result.map) {
               map = combineSourcemaps(args.path, [
-                result.map as RawSourceMap,
+                result.map === 'string' ? JSON.parse(result.map) : result.map as RawSourceMap,
                 map as RawSourceMap,
               ]) as SourceMap
             }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Brought up over here https://github.com/devongovett/unplugin-parcel-macros/issues/4

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The `type` cast to `any` on https://github.com/unjs/unplugin/blob/867b71d8f52a6fe8b32b0de801cdf3351da6ff79/src/esbuild/index.ts#L288 was hiding a bug where the result could be a string. When it was, you'd get an error such as `Cannot create property 'sourcesContent' on string '{"version":3,"sources":["test.js"]`

I'm not quite sure how to write a test for this, though, as I'm not entirely sure how this actually occurs other than possibly when passed across languages, ie rust to js. Any pointers are welcome.
I'd thought to change https://github.com/unjs/unplugin/blob/867b71d8f52a6fe8b32b0de801cdf3351da6ff79/test/fixtures/transform/unplugin.js#L35 by wrapping it in a JSON.stringify, but that didn't work.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
