### PR TITLE
fix: allow void in TransformResult

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export interface JsPluginExtended extends FarmPlugin {
   [key: string]: any
 }
 
-export type TransformResult = string | { code: string, map?: SourceMapInput | SourceMapCompact | null } | null | undefined
+export type TransformResult = string | { code: string, map?: SourceMapInput | SourceMapCompact | null } | null | undefined | void
 
 export interface ExternalIdResult { id: string, external?: boolean }
 


### PR DESCRIPTION
fix #391

Hello :wave: this PR adds `void` to `TransformResult` to avoid forcing users to specify `undefined` when `transform` does not return anything

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
