### PR TITLE
fix(esbuild): object sourcemap by overriding Object.prototype.toString

### DIFF
--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -46,7 +46,7 @@ export function unwrapLoader(
 // `load` and `transform` may return a sourcemap without toString and toUrl,
 // but esbuild needs them, we fix the two methods
 export function fixSourceMap(map: EncodedSourceMap): SourceMap {
-  if (!('toString' in map)) {
+  if (!Object.hasOwn(map, 'toString')) {
     Object.defineProperty(map, 'toString', {
       enumerable: false,
       value: function toString() {
@@ -54,7 +54,7 @@ export function fixSourceMap(map: EncodedSourceMap): SourceMap {
       },
     })
   }
-  if (!('toUrl' in map)) {
+  if (!Object.hasOwn(map, 'toUrl')) {
     Object.defineProperty(map, 'toUrl', {
       enumerable: false,
       value: function toUrl() {

--- a/src/esbuild/utils.ts
+++ b/src/esbuild/utils.ts
@@ -46,7 +46,7 @@ export function unwrapLoader(
 // `load` and `transform` may return a sourcemap without toString and toUrl,
 // but esbuild needs them, we fix the two methods
 export function fixSourceMap(map: EncodedSourceMap): SourceMap {
-  if (!Object.hasOwn(map, 'toString')) {
+  if (!Object.prototype.hasOwnProperty.call(map, 'toString')) {
     Object.defineProperty(map, 'toString', {
       enumerable: false,
       value: function toString() {
@@ -54,7 +54,7 @@ export function fixSourceMap(map: EncodedSourceMap): SourceMap {
       },
     })
   }
-  if (!Object.hasOwn(map, 'toUrl')) {
+  if (!Object.prototype.hasOwnProperty.call(map, 'toUrl')) {
     Object.defineProperty(map, 'toUrl', {
       enumerable: false,
       value: function toUrl() {


### PR DESCRIPTION
Currently, if you:

* use esbuild mode of an unplugin, and
* return a `map` from a `load` handler, where the `map` is produced by `JSON.parse`ing a JSON sourcemap (e.g. as returned by esbuild itself),

then unplugin ends up outputting a sourcemap of `[object Object]` (encoded in base64) because it overrides `toUrl` but not `toString` that's inherited from the `Object` prototype.

I believe the simple fix in this PR (use `Object.hasOwn` instead of `in`, to avoid checking prototypes) is what is intended, and it fixed the bug I was encountering.

Full (but not small) reproduction: https://github.com/DanielXMoore/Civet/tree/main/integration/unplugin-examples/esbuild with `sourceMap: true` added to `options` in `esbuild.js`, and v0.7.22 of `@danielx/civet` (I'm about to release a workaround).