### PR TITLE
fix: undetermistic module type for virtual module

### DIFF
--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -146,7 +146,7 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
                   unpluginName: plugin.name,
                 },
               }],
-              type: "javascript/auto"
+              type: 'javascript/auto',
             })
           }
 

--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -146,6 +146,7 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
                   unpluginName: plugin.name,
                 },
               }],
+              type: "javascript/auto"
             })
           }
 

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -170,7 +170,7 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
                   unpluginName: plugin.name,
                 },
               }],
-              type: "javascript/auto"
+              type: 'javascript/auto',
             })
           }
 

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -170,6 +170,7 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
                   unpluginName: plugin.name,
                 },
               }],
+              type: "javascript/auto"
             })
           }
 

--- a/test/fixtures/virtual-module/unplugin.js
+++ b/test/fixtures/virtual-module/unplugin.js
@@ -1,4 +1,4 @@
-const { createUnplugin } = require('unplugin')
+const { createUnplugin } = require('../../../')
 
 module.exports = createUnplugin(() => {
   return {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

https://github.com/unjs/unplugin/commit/ab51c6f9ef8822db2d3e87434f470183c760958c causes a bug about virtual module support in rspack, related https://github.com/web-infra-dev/rspack/issues/7787

Since `dist/rspack/vitual.js` (the placeholder module for the virtual module) is published with the unplugin package, so `unplugin/package.json#type` will affect the moduleType of virtual module:

- `type: "commonjs" => moduleType: "javascript/dynamic"` (current behavior, which will cause an error when rspack parsing any virtual module with esm syntax)
- `type: "module" => moduleType: "javascript/esm"`
- `unspecified => moduleType: "javascript/auto"`

Actually in rollup, it does not make such detailed distinctions for javascript, [all javascript will be treated as `"javascript/auto"`](https://github.com/rollup/rollup/blob/f83b3151e93253a45f5b8ccb9ccb2e04214bc490/rust/parse_ast/src/lib.rs#L44), which means all virtual modules is `"javascript/auto"`, so this PR explicitly add `type: "javascript/auto"` for virtual modules
