### PR TITLE
fix: match resource for virtual module

### DIFF
--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -10,7 +10,7 @@ import type {
   UnpluginInstance,
 } from '../types'
 import { createBuildContext, normalizeMessage } from './context'
-import { FakeVirtualModules, decodeVirtualModuleId, encodeVirtualModuleId, isVirtualModuleId } from './utils'
+import { FakeVirtualModulesPlugin, decodeVirtualModuleId, encodeVirtualModuleId, isVirtualModuleId } from './utils'
 
 const TRANSFORM_LOADER = resolve(
   __dirname,
@@ -30,7 +30,7 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
       apply(compiler) {
         // We need the prefix of virtual modules to be an absolute path so rspack let's us load them (even if it's made up)
         // In the loader we strip the made up prefix path again
-        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), '.virtual')
+        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), 'node_modules/.virtual')
 
         const injected = compiler.$unpluginContext || {}
         compiler.$unpluginContext = injected
@@ -66,7 +66,8 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
 
           // resolveId hook
           if (plugin.resolveId) {
-            const vfs = new FakeVirtualModules(plugin)
+            const vfs = new FakeVirtualModulesPlugin(plugin)
+            vfs.apply(compiler)
             plugin.__vfsModules = new Set()
 
             compiler.hooks.compilation.tap(plugin.name, (compilation, { normalModuleFactory }) => {

--- a/src/rspack/utils.ts
+++ b/src/rspack/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import { basename, dirname, resolve } from 'path'
-import { Compiler } from '@rspack/core'
+import type { Compiler } from '@rspack/core'
 import type { ResolvedUnpluginOptions } from '../types'
 
 export function encodeVirtualModuleId(id: string, plugin: ResolvedUnpluginOptions): string {

--- a/src/rspack/utils.ts
+++ b/src/rspack/utils.ts
@@ -1,13 +1,33 @@
+import fs from 'fs'
+import { basename, dirname, resolve } from 'path'
 import type { ResolvedUnpluginOptions } from '../types'
 
 export function encodeVirtualModuleId(id: string, plugin: ResolvedUnpluginOptions): string {
-  return plugin.__virtualModulePrefix + encodeURIComponent(id)
+  return resolve(plugin.__virtualModulePrefix, encodeURIComponent(id))
 }
 
-export function decodeVirtualModuleId(encoded: string, plugin: ResolvedUnpluginOptions): string {
-  return decodeURIComponent(encoded.slice(plugin.__virtualModulePrefix.length))
+export function decodeVirtualModuleId(encoded: string, _plugin: ResolvedUnpluginOptions): string {
+  return decodeURIComponent(basename(encoded))
 }
 
 export function isVirtualModuleId(encoded: string, plugin: ResolvedUnpluginOptions): boolean {
-  return encoded.startsWith(plugin.__virtualModulePrefix)
+  return dirname(encoded) === plugin.__virtualModulePrefix
+}
+
+export class FakeVirtualModules {
+  constructor(private plugin: ResolvedUnpluginOptions) {
+    const dir = this.plugin.__virtualModulePrefix
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir)
+    }
+    process.on('exit', async () => {
+      fs.rmdirSync(dir, { recursive: true })
+    })
+  }
+
+  async writeModule(file: string) {
+    const path = encodeVirtualModuleId(file, this.plugin)
+    await fs.promises.writeFile(path, '')
+    return path
+  }
 }

--- a/src/rspack/virtual.js
+++ b/src/rspack/virtual.js
@@ -1,2 +1,0 @@
-// The placeholder module for the virtual module.
-// The resourceQuery of this module contains the id of the virtual module.

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,4 @@
 import type { Options } from 'tsup'
-import { copy } from 'esbuild-plugin-copy'
 import Unused from 'unplugin-unused/esbuild'
 
 export const tsup: Options = {
@@ -26,14 +25,6 @@ export const tsup: Options = {
     __DEV__: 'false',
   },
   esbuildPlugins: [
-    copy({
-      assets: [
-        {
-          from: ['./src/rspack/virtual.js'],
-          to: ['./rspack/virtual.js'],
-        },
-      ],
-    }),
     Unused({ level: 'error' }),
   ],
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

fix #415

This PR uses `FakeVirtualModules` to write virtual module to disk (under `.virtual` directory), @hardfist is working on a real `VirtualModulesPlugin` for Rspack, which will avoid writing file to disk, I will send another PR to switch to it once it's released