### PR TITLE
ci: add node v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [16, 18, 20]
+        node: [16, 18, 20, 22]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
I think we may add node v22 also since it is the latest now.
