### PR TITLE
fix(rspack): plugin.__vfs is undefined

### DIFF
--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -69,6 +69,7 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
             const vfs = new FakeVirtualModulesPlugin(plugin)
             vfs.apply(compiler)
             plugin.__vfsModules = new Set()
+            plugin.__vfs = vfs
 
             compiler.hooks.compilation.tap(plugin.name, (compilation, { normalModuleFactory }) => {
               normalModuleFactory.hooks.resolve.tapPromise(plugin.name, async (resolveData) => {


### PR DESCRIPTION
fix 

```shell
        plugin.__vfs.writeModule(id, code);
                     ^

TypeError: Cannot read properties of undefined (reading 'writeModule')
```