### PR TITLE
Resolve #463: Update src/esbuild/index.ts for older version node.js

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -69,7 +69,9 @@ export function getEsbuildPlugin<UserOptions = Record<string, never>>(
             loader.onLoadCb = callback
           },
           onTransform(_options, callback) {
-            loader.options ||= _options
+            if (!loader.options) {
+              loader.options = _options
+            }
             loader.onTransformCb = callback
           },
         } as EsbuildPluginBuild, build)


### PR DESCRIPTION
The logical OR assignment (||=) operator is not supported on node.js v14+ which is used in src/esbuild/index.ts, so may it do a little modification to fix it? thanks.