### PR TITLE
fix(farm): modify the parameter order of addWatchFile

### DIFF
--- a/src/farm/context.ts
+++ b/src/farm/context.ts
@@ -12,7 +12,7 @@ export function createFarmContext(
     parse,
 
     addWatchFile(id: string) {
-      context.addWatchFile(currentResolveId || id, id)
+      context.addWatchFile(id, currentResolveId || id)
     },
     emitFile(emittedFile) {
       const outFileName = emittedFile.fileName || emittedFile.name


### PR DESCRIPTION
hi @sxzz  

farm modifies the `moduleId` of the `second parameter` by default to recompile the `first parameter` and store the first parameter in `watch_graph`.