### PR TITLE
fix: add error handling to transform for Rspack and webpack

### DIFF
--- a/src/rspack/loaders/transform.ts
+++ b/src/rspack/loaders/transform.ts
@@ -33,6 +33,11 @@ export default async function transform(
     else callback(null, res, map)
   }
   catch (error) {
-    callback(error as Error)
+    if (error instanceof Error) {
+      callback(error)
+    }
+    else {
+      callback(new Error(String(error)))
+    }
   }
 }

--- a/src/rspack/loaders/transform.ts
+++ b/src/rspack/loaders/transform.ts
@@ -14,19 +14,25 @@ export default async function transform(
 
   const id = this.resource
   const context = createContext(this)
-  const res = await plugin.transform.call(
-    Object.assign(
-      {},
-      this._compilation && createBuildContext(this._compiler, this._compilation, this),
-      context,
-    ),
-    source,
-    id,
-  )
 
-  if (res == null)
-    callback(null, source, map)
-  else if (typeof res !== 'string')
-    callback(null, res.code, map == null ? map : (res.map || map))
-  else callback(null, res, map)
+  try {
+    const res = await plugin.transform.call(
+      Object.assign(
+        {},
+        this._compilation && createBuildContext(this._compiler, this._compilation, this),
+        context,
+      ),
+      source,
+      id,
+    )
+
+    if (res == null)
+      callback(null, source, map)
+    else if (typeof res !== 'string')
+      callback(null, res.code, map == null ? map : (res.map || map))
+    else callback(null, res, map)
+  }
+  catch (error) {
+    callback(error as Error)
+  }
 }

--- a/src/webpack/loaders/transform.ts
+++ b/src/webpack/loaders/transform.ts
@@ -10,23 +10,29 @@ export default async function transform(this: LoaderContext<any>, source: string
     return callback(null, source, map)
 
   const context = createContext(this)
-  const res = await plugin.transform.call(
-    Object.assign({}, createBuildContext({
-      addWatchFile: (file) => {
-        this.addDependency(file)
-      },
-      getWatchFiles: () => {
-        return this.getDependencies()
-      },
-    }, this._compiler!, this._compilation, this), context),
-    source,
-    this.resource,
-  )
 
-  if (res == null)
-    callback(null, source, map)
-  else if (typeof res !== 'string')
-    callback(null, res.code, map == null ? map : (res.map || map))
-  else
-    callback(null, res, map)
+  try {
+    const res = await plugin.transform.call(
+      Object.assign({}, createBuildContext({
+        addWatchFile: (file) => {
+          this.addDependency(file)
+        },
+        getWatchFiles: () => {
+          return this.getDependencies()
+        },
+      }, this._compiler!, this._compilation, this), context),
+      source,
+      this.resource,
+    )
+
+    if (res == null)
+      callback(null, source, map)
+    else if (typeof res !== 'string')
+      callback(null, res.code, map == null ? map : (res.map || map))
+    else
+      callback(null, res, map)
+  }
+  catch (error) {
+    callback(error as Error)
+  }
 }

--- a/src/webpack/loaders/transform.ts
+++ b/src/webpack/loaders/transform.ts
@@ -33,6 +33,11 @@ export default async function transform(this: LoaderContext<any>, source: string
       callback(null, res, map)
   }
   catch (error) {
-    callback(error as Error)
+    if (error instanceof Error) {
+      callback(error)
+    }
+    else {
+      callback(new Error(String(error)))
+    }
   }
 }


### PR DESCRIPTION
## Description

Add error handling for the plugin's `transform` in the Rspack loader.

Wrapping the `plugin.transform.call()` in a try-catch block to ensure that any errors thrown during the transformation process are properly captured and passed to Rspack's error handling mechanism.

I made the same changes to the webpack loader to keep it consistent.

## Related issues

resolve https://github.com/web-infra-dev/rsbuild/issues/4789

## Preview

- dev without `try...catch` (process exit):

![image](https://github.com/user-attachments/assets/fd83dbdc-f544-4ff0-93d7-85125082679e)

- dev with `try...catch` (the error is emit by Rspack and this did not break the dev build):

![image](https://github.com/user-attachments/assets/ff572ff5-b2c6-4113-aa0f-4a498958ec27)

