### PR TITLE
build: minimum node v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=20.11.1"
   },
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
Actually node.js 18 EOL will be in this month, (https://nodejs.org/en/blog/release/v18.20.8). May be, I mean may be we can target from node v20