### PR TITLE
fix(rspack): prevent vfs concurrency issues for parallel builds

### DIFF
--- a/src/rspack/utils.ts
+++ b/src/rspack/utils.ts
@@ -17,15 +17,19 @@ export function isVirtualModuleId(encoded: string, plugin: ResolvedUnpluginOptio
 
 export class FakeVirtualModulesPlugin {
   name = 'FakeVirtualModulesPlugin'
+  static counter = 0
   constructor(private plugin: ResolvedUnpluginOptions) {}
 
   apply(compiler: Compiler): void {
+    FakeVirtualModulesPlugin.counter++
     const dir = this.plugin.__virtualModulePrefix
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true })
     }
     compiler.hooks.shutdown.tap(this.name, () => {
-      fs.rmSync(dir, { recursive: true, force: true })
+      if (--FakeVirtualModulesPlugin.counter === 0) {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
     })
   }
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Wait for all the compilers to shutdown before deleting the vfs folder.

resolves #509
