### PR TITLE
docs: fix typos in guide

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -7,9 +7,9 @@ lastUpdated: false
 
 ## Overview
 
-**Unplugin** is a library that offers an unified plugin system for various build tools. It extends the excellent [Rollup plugin API](https://rollupjs.org/plugin-development/#plugins-overview) to serve as the standard plugin interface, and provides a compatibility layer based on the build tools employed.
+**Unplugin** is a library that offers a unified plugin system for various build tools. It extends the excellent [Rollup plugin API](https://rollupjs.org/plugin-development/#plugins-overview) to serve as the standard plugin interface, and provides a compatibility layer based on the build tools employed.
 
-**Unplugin** current supports:
+**Unplugin** currently supports:
 
 - [Vite](https://vite.dev/)
 - [Rollup](https://rollupjs.org/)


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
This PR corrects two minor grammar issues in the Getting Started guide (docs/guide/index.md):
- Changed "an unified plugin system" to "a unified plugin system"
- Changed "Unplugin current supports" to "Unplugin currently supports"