### PR TITLE
fix(rspack): gate virtual folder behind process pid

### DIFF
--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -32,7 +32,7 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
       apply(compiler) {
         // We need the prefix of virtual modules to be an absolute path so rspack lets us load them (even if it's made up)
         // In the loader we strip the made up prefix path again
-        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), 'node_modules/.virtual')
+        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), 'node_modules/.virtual', process.pid.toString())
 
         const meta: UnpluginContextMeta = {
           framework: 'rspack',


### PR DESCRIPTION
_Should resolve #537_

- adds a `process.pid` suffix to  the `node_modules/.virtual` folder to stop sharing the folder between parallel rspack runs in separate processes
- adds handlers on process exit and interrupt/kill signals to clean up the virtual subfolder when the process stops
- the `static counter` property is currently shared between all virtual paths/contexts. This PR turns it into a Map of counters indexed by path to ensure that every pending virtual folder (and not only the last one) will get deleted when the final running compiler shuts down.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
