### PR TITLE
chore(rspack): remove pid in virtual path when unnecessary

### DIFF
--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -32,7 +32,7 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
       apply(compiler) {
         // We need the prefix of virtual modules to be an absolute path so rspack lets us load them (even if it's made up)
         // In the loader we strip the made up prefix path again
-        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), 'node_modules/.virtual', process.pid.toString())
+        const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), 'node_modules/.virtual', compiler.rspack.experiments.VirtualModulesPlugin ? '' : process.pid.toString())
 
         const meta: UnpluginContextMeta = {
           framework: 'rspack',


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

👋 **A small follow-up to:**
- #538
- #542

Basically a very simple gate to prevent inserting the `process.pid()` when the native virtual plugin is used, the rationale is:
- the native plugin writes virtual files in memory, so there should not be cross-process fs concurrency issues and the pid prefix is unnecessary
- the pid changes for every compilation, defeating long term caching strategies relying on the content hash