### PR TITLE
fix: binary file corruption in webpack loaders

### DIFF
--- a/src/webpack/loaders/load.ts
+++ b/src/webpack/loaders/load.ts
@@ -4,6 +4,8 @@ import { normalizeObjectHook } from '../../utils/filter'
 import { normalizeAbsolutePath } from '../../utils/webpack-like'
 import { createBuildContext, createContext } from '../context'
 
+export const raw = true
+
 export default async function load(this: LoaderContext<any>, source: string, map: any): Promise<void> {
   const callback = this.async()
   const { plugin } = this.query as { plugin: ResolvedUnpluginOptions }

--- a/src/webpack/loaders/transform.ts
+++ b/src/webpack/loaders/transform.ts
@@ -3,6 +3,8 @@ import type { ResolvedUnpluginOptions } from '../../types'
 import { normalizeObjectHook } from '../../utils/filter'
 import { createBuildContext, createContext } from '../context'
 
+export const raw = true
+
 export default async function transform(this: LoaderContext<any>, source: string, map: any): Promise<void> {
   const callback = this.async()
 


### PR DESCRIPTION
Webpack loaders were treating binary files (images, fonts) as text which corrupted them. Added `raw = true` export to both load and transform loaders so webpack handles them as binary data instead of strings.

Fixes #524