### PR TITLE
Expose input source map for webpack-like bundlers

### DIFF
--- a/src/rspack/context.ts
+++ b/src/rspack/context.ts
@@ -4,7 +4,7 @@ import { Buffer } from 'node:buffer'
 import { resolve } from 'node:path'
 import { parse } from '../utils/parse'
 
-export function createBuildContext(compiler: Compiler, compilation: Compilation, loaderContext?: LoaderContext): UnpluginBuildContext {
+export function createBuildContext(compiler: Compiler, compilation: Compilation, loaderContext?: LoaderContext, inputSourceMap?: any): UnpluginBuildContext {
   return {
     getNativeBuildContext() {
       return {
@@ -12,6 +12,7 @@ export function createBuildContext(compiler: Compiler, compilation: Compilation,
         compiler,
         compilation,
         loaderContext,
+        inputSourceMap,
       }
     },
     addWatchFile(file) {

--- a/src/rspack/loaders/transform.ts
+++ b/src/rspack/loaders/transform.ts
@@ -23,7 +23,7 @@ export default async function transform(
     const res = await handler.call(
       Object.assign(
         {},
-        this._compilation && createBuildContext(this._compiler, this._compilation, this),
+        this._compilation && createBuildContext(this._compiler, this._compilation, this, map),
         context,
       ),
       source,

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,9 +50,9 @@ export type TransformResult = string | { code: string, map?: SourceMapInput | So
 export interface ExternalIdResult { id: string, external?: boolean | undefined }
 
 export type NativeBuildContext
-  = { framework: 'webpack', compiler: WebpackCompiler, compilation?: WebpackCompilation | undefined, loaderContext?: WebpackLoaderContext<{ unpluginName: string }> | undefined }
+  = { framework: 'webpack', compiler: WebpackCompiler, compilation?: WebpackCompilation | undefined, loaderContext?: WebpackLoaderContext<{ unpluginName: string }> | undefined, inputSourceMap?: any }
     | { framework: 'esbuild', build: PluginBuild }
-    | { framework: 'rspack', compiler: RspackCompiler, compilation: RspackCompilation, loaderContext?: RspackLoaderContext | undefined }
+    | { framework: 'rspack', compiler: RspackCompiler, compilation: RspackCompilation, loaderContext?: RspackLoaderContext | undefined, inputSourceMap?: any }
     | { framework: 'farm', context: FarmCompilationContext }
     | { framework: 'bun', build: BunPluginBuilder }
 

--- a/src/webpack/context.ts
+++ b/src/webpack/context.ts
@@ -30,7 +30,7 @@ export function getSource(fileSource: string | Uint8Array): sources.RawSource {
   )
 }
 
-export function createBuildContext(options: ContextOptions, compiler: Compiler, compilation?: Compilation, loaderContext?: LoaderContext<{ unpluginName: string }>): UnpluginBuildContext {
+export function createBuildContext(options: ContextOptions, compiler: Compiler, compilation?: Compilation, loaderContext?: LoaderContext<{ unpluginName: string }>, inputSourceMap?: any): UnpluginBuildContext {
   return {
     parse,
     addWatchFile(id) {
@@ -51,7 +51,7 @@ export function createBuildContext(options: ContextOptions, compiler: Compiler, 
       return options.getWatchFiles()
     },
     getNativeBuildContext() {
-      return { framework: 'webpack', compiler, compilation, loaderContext }
+      return { framework: 'webpack', compiler, compilation, loaderContext, inputSourceMap }
     },
   }
 }

--- a/src/webpack/loaders/transform.ts
+++ b/src/webpack/loaders/transform.ts
@@ -24,7 +24,7 @@ export default async function transform(this: LoaderContext<any>, source: string
         getWatchFiles: () => {
           return this.getDependencies()
         },
-      }, this._compiler!, this._compilation, this), context),
+      }, this._compiler!, this._compilation, this, map), context),
       source,
       this.resource,
     )

--- a/test/unit-tests/rspack/context.test.ts
+++ b/test/unit-tests/rspack/context.test.ts
@@ -7,14 +7,16 @@ describe('createBuildContext', () => {
     const compiler = { name: 'testCompiler' }
     const compilation = { name: 'testCompilation' }
     const loaderContext = { name: 'testLoaderContext' }
+    const inputSourceMap = { name: 'inputSourceMap' }
 
-    const buildContext = createBuildContext(compiler as any, compilation as any, loaderContext as any)
+    const buildContext = createBuildContext(compiler as any, compilation as any, loaderContext as any, inputSourceMap as any)
 
     expect(buildContext.getNativeBuildContext!()).toEqual({
       framework: 'rspack',
       compiler,
       compilation,
       loaderContext,
+      inputSourceMap,
     })
   })
 

--- a/test/unit-tests/webpack/context.test.ts
+++ b/test/unit-tests/webpack/context.test.ts
@@ -46,6 +46,27 @@ describe('webpack - utils', () => {
         expect.anything(),
       )
     })
+
+    it('should add expected values to native build context', () => {
+      const options = {
+        addWatchFile: vi.fn(),
+        getWatchFiles: vi.fn(() => ['file1.js']),
+      }
+      const compiler = { name: 'testCompiler' } as Compiler
+      const compilation = { name: 'testCompilation' } as Compilation
+      const loaderContext = { name: 'testLoaderContext' } as unknown as LoaderContext<{ unpluginName: string }>
+      const inputSourceMap = { name: 'inputSourceMap' }
+
+      const buildContext = createBuildContext(options, compiler, compilation, loaderContext, inputSourceMap)
+
+      expect(buildContext.getNativeBuildContext!()).toEqual({
+        framework: 'webpack',
+        compiler,
+        compilation,
+        loaderContext,
+        inputSourceMap,
+      })
+    })
   })
 
   describe('createContext', () => {


### PR DESCRIPTION
This PR exposes the input source map for rspack and webpack, making it possible for Unplugin-based plugins to chain source maps from earlier loaders correctly. Resolves #561.