### PR TITLE
feat: `meta.versions` support

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -449,13 +449,14 @@ When your plugin needs behavior depending on the exact bundler version,
 use `meta.frameworkVersion` which is the version string `"x.y.z"`
 from the host framework version.
 
-|     Rollup     |      Vite      | webpack | Rspack | esbuild | Farm |    Rolldown    |    Unloader    | Bun |
-| :------------: | :------------: | :-----: | :----: | :-----: | :--: | :------------: | :------------: | :-: |
-| ✅<sup>1</sup> | ✅<sup>1</sup> |   ✅    |   ✅   |   ❌    |  ❌  | ✅<sup>1</sup> | ✅<sup>1</sup> | ✅  |
+|     Rollup     |       Vite       | webpack | Rspack | esbuild | Farm |    Rolldown    |    Unloader    | Bun |
+| :------------: | :--------------: | :-----: | :----: | :-----: | :--: | :------------: | :------------: | :-: |
+| ✅<sup>1</sup> | ✅<sup>1,2</sup> |   ✅    |   ✅   |   ❌    |  ❌  | ✅<sup>1</sup> | ✅<sup>1</sup> | ✅  |
 
 ::: details Notice
 
 1. For Rollup-compatible hosts (`vite`, `rollup`, `rolldown`, `unloader`), `frameworkVersion` is not available until hook code, starting with `buildStart`.
+2. Vite added `this.meta.viteVersion` in `v7.0.0` ([vitejs/vite#20088](https://github.com/vitejs/vite/pull/20088)). On Vite versions before `v7.0.0`, `meta.frameworkVersion` is `undefined`.
 
 :::
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -374,7 +374,7 @@ While **Unplugin** provides compatible layers for some hooks, the functionality 
 
 ### Hooks
 
-```ts {9,18,20,26,29,32,35,38,50} twoslash
+```ts {9,18,24,27,30,33,36,48} twoslash
 import type { UnpluginFactory } from 'unplugin'
 import { createUnplugin } from 'unplugin'
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -386,11 +386,15 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (
   options,
   meta,
 ) => {
-  console.log(meta.framework) // vite rollup webpack esbuild rspack...
+  // unplugin context meta
+  console.log(meta.framework) // vite | rollup | webpack | esbuild | rspack | farm | bun
+
   return {
     name: 'unplugin-starter',
     buildStart() {
-      console.log(meta.frameworkVersion) // x.y.z
+      // framework version is available since buildStart hook
+      // not all frameworks support provides version info
+      console.log(meta.frameworkVersion) // x.y.z | undefined
     },
     transform: {
       // an additional hook is needed for better perf on webpack and rolldown
@@ -447,7 +451,9 @@ export default unplugin
 
 When your plugin needs behavior depending on the exact bundler version,
 use `meta.frameworkVersion` which is the version string `"x.y.z"`
-from the host framework version.
+from the host framework version, or `undefined` if the framework does not provide version info.
+
+Also note that the `frameworkVersion` is usually only available after the `buildStart` hook, before that it might be `undefined`.
 
 |     Rollup     |       Vite       | webpack | Rspack | esbuild | Farm |    Rolldown    |    Unloader    | Bun |
 | :------------: | :--------------: | :-----: | :----: | :-----: | :--: | :------------: | :------------: | :-: |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -374,7 +374,7 @@ While **Unplugin** provides compatible layers for some hooks, the functionality 
 
 ### Hooks
 
-```ts {9,18,24,27,30,33,36,48} twoslash
+```ts {9,18,20,26,29,32,35,38,50} twoslash
 import type { UnpluginFactory } from 'unplugin'
 import { createUnplugin } from 'unplugin'
 
@@ -389,6 +389,9 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (
   console.log(meta.framework) // vite rollup webpack esbuild rspack...
   return {
     name: 'unplugin-starter',
+    buildStart() {
+      console.log(meta.frameworkVersion) // x.y.z
+    },
     transform: {
       // an additional hook is needed for better perf on webpack and rolldown
       filter: {
@@ -439,6 +442,22 @@ export const unplugin = /* #__PURE__ */ createUnplugin(unpluginFactory)
 
 export default unplugin
 ```
+
+#### `meta.frameworkVersion`
+
+When your plugin needs behavior depending on the exact bundler version,
+use `meta.frameworkVersion` which is the version string `"x.y.z"`
+from the host framework version.
+
+|     Rollup     |      Vite      | webpack | Rspack | esbuild | Farm |    Rolldown    |    Unloader    | Bun |
+| :------------: | :------------: | :-----: | :----: | :-----: | :--: | :------------: | :------------: | :-: |
+| ✅<sup>1</sup> | ✅<sup>1</sup> |   ✅    |   ✅   |   ❌    |  ❌  | ✅<sup>1</sup> | ✅<sup>1</sup> | ✅  |
+
+::: details Notice
+
+1. For Rollup-compatible hosts (`vite`, `rollup`, `rolldown`, `unloader`), `frameworkVersion` is not available until hook code, starting with `buildStart`.
+
+:::
 
 ### Plugins
 

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,6 +1,7 @@
 import type { BunPlugin, Loader } from 'bun'
 import type { TransformResult, UnpluginContextMeta, UnpluginFactory, UnpluginInstance } from '../types'
 import { isAbsolute } from 'node:path'
+import { version as unpluginVersion } from '../../package.json'
 import { normalizeObjectHook } from '../utils/filter'
 import { toArray } from '../utils/general'
 import { createBuildContext, createPluginContext, guessLoader } from './utils'
@@ -19,7 +20,7 @@ export function getBunPlugin<UserOptions = Record<string, never>>(
 
     const meta: UnpluginContextMeta = {
       framework: 'bun',
-      frameworkVersion: Bun.version,
+      versions: { bun: Bun.version, unplugin: unpluginVersion },
     }
 
     const plugins = toArray(factory(userOptions!, meta))

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -19,6 +19,7 @@ export function getBunPlugin<UserOptions = Record<string, never>>(
 
     const meta: UnpluginContextMeta = {
       framework: 'bun',
+      frameworkVersion: Bun.version,
     }
 
     const plugins = toArray(factory(userOptions!, meta))

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -10,6 +10,7 @@ import type {
 } from '../types'
 import fs from 'node:fs'
 import path from 'node:path'
+import { version as unpluginVersion } from '../../package.json'
 import { normalizeObjectHook } from '../utils/filter'
 import { toArray } from '../utils/general'
 import {
@@ -54,6 +55,7 @@ export function getEsbuildPlugin<UserOptions = Record<string, never>>(
   return (userOptions?: UserOptions): EsbuildPlugin => {
     const meta: UnpluginContextMeta = {
       framework: 'esbuild',
+      versions: { unplugin: unpluginVersion }, // esbuild doesn't expose version to plugins
     }
     const plugins = toArray(factory(userOptions!, meta))
 

--- a/src/farm/index.ts
+++ b/src/farm/index.ts
@@ -17,6 +17,7 @@ import type {
 import type { JsPluginExtended, WatchChangeEvents } from './utils'
 
 import path from 'node:path'
+import { version as unpluginVersion } from '../../package.json'
 
 import { normalizeObjectHook } from '../utils/filter'
 import { toArray } from '../utils/general'
@@ -43,6 +44,7 @@ export function getFarmPlugin<
   return ((userOptions?: UserOptions) => {
     const meta: UnpluginContextMeta = {
       framework: 'farm',
+      versions: { unplugin: unpluginVersion }, // farm doesn't expose version to plugins yet
     }
     const rawPlugins = toArray(factory(userOptions!, meta))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { version } from '../package.json'
 export * from './define'
 export * from './types'
 export { setParseImpl } from './utils/parse'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-export { version } from '../package.json'
+import pkg from '../package.json' with { type: 'json' }
+
+export const version: string = pkg.version
+
 export * from './define'
 export * from './types'
 export { setParseImpl } from './utils/parse'

--- a/src/rolldown/index.ts
+++ b/src/rolldown/index.ts
@@ -12,7 +12,7 @@ export function getRolldownPlugin<UserOptions = Record<string, never>, Nested ex
     const rawPlugins = toArray(factory(userOptions!, meta))
 
     const plugins = rawPlugins.map((rawPlugin) => {
-      const plugin = toRollupPlugin(rawPlugin, 'rolldown') as RolldownPlugin
+      const plugin = toRollupPlugin(rawPlugin, 'rolldown', meta) as RolldownPlugin
       return plugin
     })
 

--- a/src/rolldown/index.ts
+++ b/src/rolldown/index.ts
@@ -1,4 +1,5 @@
 import type { RolldownPlugin, UnpluginContextMeta, UnpluginFactory, UnpluginInstance } from '../types'
+import { version as unpluginVersion } from '../../package.json'
 import { toRollupPlugin } from '../rollup'
 import { toArray } from '../utils/general'
 
@@ -8,6 +9,7 @@ export function getRolldownPlugin<UserOptions = Record<string, never>, Nested ex
   return ((userOptions?: UserOptions) => {
     const meta: UnpluginContextMeta = {
       framework: 'rolldown',
+      versions: { unplugin: unpluginVersion }, // Will be populated in buildStart hook
     }
     const rawPlugins = toArray(factory(userOptions!, meta))
 

--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -38,6 +38,7 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
 
         const meta: UnpluginContextMeta = {
           framework: 'rspack',
+          frameworkVersion: (compiler as any).rspack?.rspackVersion ?? (compiler as any).rspack?.version,
           rspack: {
             compiler,
           },

--- a/src/rspack/index.ts
+++ b/src/rspack/index.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types'
 import fs from 'node:fs'
 import { resolve } from 'node:path'
+import { version as unpluginVersion } from '../../package.json'
 import { normalizeObjectHook } from '../utils/filter'
 import { toArray } from '../utils/general'
 import { normalizeAbsolutePath, transformUse } from '../utils/webpack-like'
@@ -36,9 +37,10 @@ export function getRspackPlugin<UserOptions = Record<string, never>>(
         // In the loader we strip the made up prefix path again
         const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), 'node_modules/.virtual', compiler.rspack.experiments.VirtualModulesPlugin ? '' : process.pid.toString())
 
+        const version = (compiler as any).rspack?.rspackVersion ?? (compiler as any).rspack?.version
         const meta: UnpluginContextMeta = {
           framework: 'rspack',
-          frameworkVersion: (compiler as any).rspack?.rspackVersion ?? (compiler as any).rspack?.version,
+          versions: { rspack: version, unplugin: unpluginVersion },
           rspack: {
             compiler,
           },

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,8 +176,20 @@ export interface UnpluginInstance<UserOptions, Nested extends boolean = boolean>
   raw: UnpluginFactory<UserOptions, Nested>
 }
 
+export type SupportedFramework = 'rollup' | 'vite' | 'rolldown' | 'farm' | 'unloader' | 'webpack' | 'rspack' | 'esbuild' | 'bun'
+
 export type UnpluginContextMeta = Partial<RollupContextMeta> & {
-  frameworkVersion?: string | undefined
+  /**
+   * Version information for frameworks.
+   * Access the current framework version via: `meta.versions[meta.framework]`
+   *
+   * For Vite, includes both Vite's version and the underlying bundler (Rollup/Rolldown).
+   * For Rollup-compatible frameworks (vite, rollup, rolldown, unloader),
+   * versions are only available after the `buildStart` hook.
+   *
+   * The `unplugin` version is always available for all frameworks.
+   */
+  versions: Partial<Record<SupportedFramework | 'unplugin', string>>
 } & ({
   framework: 'rollup' | 'vite' | 'rolldown' | 'farm' | 'unloader'
 } | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,7 +176,9 @@ export interface UnpluginInstance<UserOptions, Nested extends boolean = boolean>
   raw: UnpluginFactory<UserOptions, Nested>
 }
 
-export type UnpluginContextMeta = Partial<RollupContextMeta> & ({
+export type UnpluginContextMeta = Partial<RollupContextMeta> & {
+  frameworkVersion?: string | undefined
+} & ({
   framework: 'rollup' | 'vite' | 'rolldown' | 'farm' | 'unloader'
 } | {
   framework: 'webpack'

--- a/src/unloader/index.ts
+++ b/src/unloader/index.ts
@@ -12,7 +12,7 @@ export function getUnloaderPlugin<UserOptions = Record<string, never>, Nested ex
     const rawPlugins = toArray(factory(userOptions!, meta))
 
     const plugins = rawPlugins.map((rawPlugin) => {
-      const plugin = toRollupPlugin(rawPlugin, 'unloader') as UnloaderPlugin
+      const plugin = toRollupPlugin(rawPlugin, 'unloader', meta) as UnloaderPlugin
       return plugin
     })
 

--- a/src/unloader/index.ts
+++ b/src/unloader/index.ts
@@ -1,4 +1,5 @@
 import type { UnloaderPlugin, UnpluginContextMeta, UnpluginFactory, UnpluginInstance } from '../types'
+import { version as unpluginVersion } from '../../package.json'
 import { toRollupPlugin } from '../rollup'
 import { toArray } from '../utils/general'
 
@@ -8,6 +9,7 @@ export function getUnloaderPlugin<UserOptions = Record<string, never>, Nested ex
   return ((userOptions?: UserOptions) => {
     const meta: UnpluginContextMeta = {
       framework: 'unloader',
+      versions: { unplugin: unpluginVersion }, // Will be populated in buildStart hook
     }
     const rawPlugins = toArray(factory(userOptions!, meta))
 

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -12,7 +12,7 @@ export function getVitePlugin<UserOptions = Record<string, never>, Nested extend
     const rawPlugins = toArray(factory(userOptions!, meta))
 
     const plugins = rawPlugins.map((rawPlugin) => {
-      const plugin = toRollupPlugin(rawPlugin, 'vite') as VitePlugin
+      const plugin = toRollupPlugin(rawPlugin, 'vite', meta) as VitePlugin
       return plugin
     })
 

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -1,4 +1,5 @@
 import type { UnpluginContextMeta, UnpluginFactory, UnpluginInstance, VitePlugin } from '../types'
+import { version as unpluginVersion } from '../../package.json'
 import { toRollupPlugin } from '../rollup'
 import { toArray } from '../utils/general'
 
@@ -8,6 +9,7 @@ export function getVitePlugin<UserOptions = Record<string, never>, Nested extend
   return ((userOptions?: UserOptions) => {
     const meta: UnpluginContextMeta = {
       framework: 'vite',
+      versions: { unplugin: unpluginVersion }, // Will be populated in buildStart hook
     }
     const rawPlugins = toArray(factory(userOptions!, meta))
 

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -35,6 +35,7 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
 
         const meta: UnpluginContextMeta = {
           framework: 'webpack',
+          frameworkVersion: (compiler as any).webpack?.version,
           webpack: {
             compiler,
           },

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -4,6 +4,7 @@ import type { ResolvedUnpluginOptions, UnpluginContext, UnpluginContextMeta, Unp
 import fs from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
+import { version as unpluginVersion } from '../../package.json'
 import { normalizeObjectHook } from '../utils/filter'
 import { toArray } from '../utils/general'
 import { normalizeAbsolutePath, transformUse } from '../utils/webpack-like'
@@ -33,9 +34,10 @@ export function getWebpackPlugin<UserOptions = Record<string, never>>(
         // In the loader we strip the made up prefix path again
         const VIRTUAL_MODULE_PREFIX = resolve(compiler.options.context ?? process.cwd(), '_virtual_')
 
+        const version = (compiler as any).webpack?.version
         const meta: UnpluginContextMeta = {
           framework: 'webpack',
-          frameworkVersion: (compiler as any).webpack?.version,
+          versions: { webpack: version, unplugin: unpluginVersion },
           webpack: {
             compiler,
           },

--- a/test/unit-tests/framework-version/index.test.ts
+++ b/test/unit-tests/framework-version/index.test.ts
@@ -17,15 +17,17 @@ const rspackVersion: string = require('@rspack/core/package.json').version
 const entry = path.resolve(__dirname, '../filter/test-src/entry.js')
 const runWithRegisterHooks = typeof (nodeModule as any).registerHooks === 'function' ? it : it.skip
 
-describe('frameworkVersion', () => {
-  it('rollup sets frameworkVersion from rollupVersion', async () => {
+describe('framework versions', () => {
+  it('rollup sets versions.rollup', async () => {
     let hostVersion: string | undefined
-    let frameworkVersion: string | undefined
+    let versionsRollup: string | undefined
+    let allVersions: Partial<Record<string, string>> | undefined
     const plugin = createUnplugin((_options, meta) => ({
-      name: 'framework-version-rollup',
+      name: 'framework-versions-rollup',
       buildStart() {
         hostVersion = (this as any).meta?.rollupVersion
-        frameworkVersion = meta.frameworkVersion
+        versionsRollup = meta.versions.rollup
+        allVersions = meta.versions
       },
     }))
 
@@ -35,17 +37,20 @@ describe('frameworkVersion', () => {
     })
 
     expect(hostVersion).toBe(rollupVersion)
-    expect(frameworkVersion).toBe(rollupVersion)
+    expect(versionsRollup).toBe(rollupVersion)
+    expect(allVersions).toMatchObject({ rollup: rollupVersion, unplugin: expect.any(String) })
   })
 
-  it('vite sets frameworkVersion from viteVersion', async () => {
+  it('vite sets versions.vite and underlying bundler version', async () => {
     let hostVersion: string | undefined
-    let frameworkVersion: string | undefined
+    let versionsVite: string | undefined
+    let allVersions: Partial<Record<string, string>> | undefined
     const plugin = createUnplugin((_options, meta) => ({
-      name: 'framework-version-vite',
+      name: 'framework-versions-vite',
       buildStart() {
         hostVersion = (this as any).meta?.viteVersion
-        frameworkVersion = meta.frameworkVersion
+        versionsVite = meta.versions.vite
+        allVersions = meta.versions
       },
     }))
 
@@ -62,17 +67,23 @@ describe('frameworkVersion', () => {
     })
 
     expect(hostVersion).toBe(viteVersion)
-    expect(frameworkVersion).toBe(viteVersion)
+    expect(versionsVite).toBe(viteVersion)
+    // Vite uses either Rollup or Rolldown as underlying bundler
+    expect(allVersions?.vite).toBe(viteVersion)
+    expect(allVersions?.rollup || allVersions?.rolldown).toBeDefined()
+    expect(allVersions?.unplugin).toBeDefined()
   })
 
-  it('rolldown sets frameworkVersion from rolldownVersion', async () => {
+  it('rolldown sets versions.rolldown', async () => {
     let hostVersion: string | undefined
-    let frameworkVersion: string | undefined
+    let versionsRolldown: string | undefined
+    let allVersions: Partial<Record<string, string>> | undefined
     const plugin = createUnplugin((_options, meta) => ({
-      name: 'framework-version-rolldown',
+      name: 'framework-versions-rolldown',
       buildStart() {
         hostVersion = (this as any).meta?.rolldownVersion
-        frameworkVersion = meta.frameworkVersion
+        versionsRolldown = meta.versions.rolldown
+        allVersions = meta.versions
       },
     }))
 
@@ -82,17 +93,20 @@ describe('frameworkVersion', () => {
     })
 
     expect(hostVersion).toBe(rolldownVersion)
-    expect(frameworkVersion).toBe(rolldownVersion)
+    expect(versionsRolldown).toBe(rolldownVersion)
+    expect(allVersions).toMatchObject({ rolldown: rolldownVersion, unplugin: expect.any(String) })
   })
 
-  runWithRegisterHooks('unloader sets frameworkVersion from unloaderVersion', () => {
+  runWithRegisterHooks('unloader sets versions.unloader', () => {
     let hostVersion: string | undefined
-    let frameworkVersion: string | undefined
+    let versionsUnloader: string | undefined
+    let allVersions: Partial<Record<string, string>> | undefined
     const plugin = createUnplugin<undefined, false>((_options, meta) => ({
-      name: 'framework-version-unloader',
+      name: 'framework-versions-unloader',
       buildStart() {
         hostVersion = (this as any).meta?.unloaderVersion
-        frameworkVersion = meta.frameworkVersion
+        versionsUnloader = meta.versions.unloader
+        allVersions = meta.versions
       },
     }))
 
@@ -102,17 +116,20 @@ describe('frameworkVersion', () => {
     deactivate()
 
     expect(hostVersion).toBe(unloaderVersion)
-    expect(frameworkVersion).toBe(unloaderVersion)
+    expect(versionsUnloader).toBe(unloaderVersion)
+    expect(allVersions).toMatchObject({ unloader: unloaderVersion, unplugin: expect.any(String) })
   })
 
-  it('webpack sets frameworkVersion from compiler.webpack.version', async () => {
+  it('webpack sets versions.webpack', async () => {
     let hostVersion: string | undefined
-    let frameworkVersion: string | undefined
+    let versionsWebpack: string | undefined
+    let allVersions: Partial<Record<string, string>> | undefined
     const plugin = createUnplugin((_options, meta) => ({
-      name: 'framework-version-webpack',
+      name: 'framework-versions-webpack',
       buildStart() {
         hostVersion = (this.getNativeBuildContext?.() as any)?.compiler?.webpack?.version
-        frameworkVersion = meta.frameworkVersion
+        versionsWebpack = meta.versions.webpack
+        allVersions = meta.versions
       },
     }))
 
@@ -127,17 +144,20 @@ describe('frameworkVersion', () => {
     })
 
     expect(hostVersion).toBe(webpackVersion)
-    expect(frameworkVersion).toBe(webpackVersion)
+    expect(versionsWebpack).toBe(webpackVersion)
+    expect(allVersions).toMatchObject({ webpack: webpackVersion, unplugin: expect.any(String) })
   }, 20_000)
 
-  it('rspack sets frameworkVersion from compiler.rspack.rspackVersion', async () => {
+  it('rspack sets versions.rspack', async () => {
     let hostVersion: string | undefined
-    let frameworkVersion: string | undefined
+    let versionsRspack: string | undefined
+    let allVersions: Partial<Record<string, string>> | undefined
     const plugin = createUnplugin((_options, meta) => ({
-      name: 'framework-version-rspack',
+      name: 'framework-versions-rspack',
       buildStart() {
         hostVersion = (this.getNativeBuildContext?.() as any)?.compiler?.rspack?.rspackVersion
-        frameworkVersion = meta.frameworkVersion
+        versionsRspack = meta.versions.rspack
+        allVersions = meta.versions
       },
     }))
 
@@ -152,17 +172,20 @@ describe('frameworkVersion', () => {
     })
 
     expect(hostVersion).toBe(rspackVersion)
-    expect(frameworkVersion).toBe(rspackVersion)
+    expect(versionsRspack).toBe(rspackVersion)
+    expect(allVersions).toMatchObject({ rspack: rspackVersion, unplugin: expect.any(String) })
   }, 20_000)
 
-  onlyBun('bun sets frameworkVersion from Bun.version', async () => {
+  onlyBun('bun sets versions.bun', async () => {
     let hostVersion: string | undefined
-    let frameworkVersion: string | undefined
+    let versionsBun: string | undefined
+    let allVersions: Partial<Record<string, string>> | undefined
     const plugin = createUnplugin<undefined, false>((_options, meta) => ({
-      name: 'framework-version-bun',
+      name: 'framework-versions-bun',
       buildStart() {
         hostVersion = Bun.version
-        frameworkVersion = meta.frameworkVersion
+        versionsBun = meta.versions.bun
+        allVersions = meta.versions
       },
     }))
 
@@ -173,6 +196,7 @@ describe('frameworkVersion', () => {
     })
 
     expect(hostVersion).toBe(Bun.version)
-    expect(frameworkVersion).toBe(Bun.version)
+    expect(versionsBun).toBe(Bun.version)
+    expect(allVersions).toMatchObject({ bun: Bun.version, unplugin: expect.any(String) })
   })
 })

--- a/test/unit-tests/framework-version/index.test.ts
+++ b/test/unit-tests/framework-version/index.test.ts
@@ -1,5 +1,4 @@
-import { createRequire } from 'node:module'
-import nodeModule from 'node:module'
+import nodeModule, { createRequire } from 'node:module'
 import path from 'node:path'
 import { registerSync } from 'unloader'
 import { describe, expect, it } from 'vitest'

--- a/test/unit-tests/framework-version/index.test.ts
+++ b/test/unit-tests/framework-version/index.test.ts
@@ -1,0 +1,179 @@
+import { createRequire } from 'node:module'
+import nodeModule from 'node:module'
+import path from 'node:path'
+import { registerSync } from 'unloader'
+import { describe, expect, it } from 'vitest'
+import { createUnplugin } from '../../../src/define'
+import { onlyBun } from '../../utils'
+import { build } from '../utils'
+
+const require = createRequire(import.meta.url)
+const rollupVersion: string = require('rollup/package.json').version
+const viteVersion: string = require('vite/package.json').version
+const rolldownVersion: string = require('rolldown/package.json').version
+const unloaderVersion: string = require('unloader/package.json').version
+const webpackVersion: string = require('webpack/package.json').version
+const rspackVersion: string = require('@rspack/core/package.json').version
+
+const entry = path.resolve(__dirname, '../filter/test-src/entry.js')
+const runWithRegisterHooks = typeof (nodeModule as any).registerHooks === 'function' ? it : it.skip
+
+describe('frameworkVersion', () => {
+  it('rollup sets frameworkVersion from rollupVersion', async () => {
+    let hostVersion: string | undefined
+    let frameworkVersion: string | undefined
+    const plugin = createUnplugin((_options, meta) => ({
+      name: 'framework-version-rollup',
+      buildStart() {
+        hostVersion = (this as any).meta?.rollupVersion
+        frameworkVersion = meta.frameworkVersion
+      },
+    }))
+
+    await build.rollup({
+      input: entry,
+      plugins: [plugin.rollup()],
+    })
+
+    expect(hostVersion).toBe(rollupVersion)
+    expect(frameworkVersion).toBe(rollupVersion)
+  })
+
+  it('vite sets frameworkVersion from viteVersion', async () => {
+    let hostVersion: string | undefined
+    let frameworkVersion: string | undefined
+    const plugin = createUnplugin((_options, meta) => ({
+      name: 'framework-version-vite',
+      buildStart() {
+        hostVersion = (this as any).meta?.viteVersion
+        frameworkVersion = meta.frameworkVersion
+      },
+    }))
+
+    await build.vite({
+      clearScreen: false,
+      plugins: [plugin.vite()],
+      build: {
+        lib: {
+          entry,
+          name: 'TestLib',
+        },
+        write: false,
+      },
+    })
+
+    expect(hostVersion).toBe(viteVersion)
+    expect(frameworkVersion).toBe(viteVersion)
+  })
+
+  it('rolldown sets frameworkVersion from rolldownVersion', async () => {
+    let hostVersion: string | undefined
+    let frameworkVersion: string | undefined
+    const plugin = createUnplugin((_options, meta) => ({
+      name: 'framework-version-rolldown',
+      buildStart() {
+        hostVersion = (this as any).meta?.rolldownVersion
+        frameworkVersion = meta.frameworkVersion
+      },
+    }))
+
+    await build.rolldown({
+      input: entry,
+      plugins: [plugin.rolldown()],
+    })
+
+    expect(hostVersion).toBe(rolldownVersion)
+    expect(frameworkVersion).toBe(rolldownVersion)
+  })
+
+  runWithRegisterHooks('unloader sets frameworkVersion from unloaderVersion', () => {
+    let hostVersion: string | undefined
+    let frameworkVersion: string | undefined
+    const plugin = createUnplugin<undefined, false>((_options, meta) => ({
+      name: 'framework-version-unloader',
+      buildStart() {
+        hostVersion = (this as any).meta?.unloaderVersion
+        frameworkVersion = meta.frameworkVersion
+      },
+    }))
+
+    const deactivate = registerSync({
+      plugins: [plugin.unloader() as any],
+    })
+    deactivate()
+
+    expect(hostVersion).toBe(unloaderVersion)
+    expect(frameworkVersion).toBe(unloaderVersion)
+  })
+
+  it('webpack sets frameworkVersion from compiler.webpack.version', async () => {
+    let hostVersion: string | undefined
+    let frameworkVersion: string | undefined
+    const plugin = createUnplugin((_options, meta) => ({
+      name: 'framework-version-webpack',
+      buildStart() {
+        hostVersion = (this.getNativeBuildContext?.() as any)?.compiler?.webpack?.version
+        frameworkVersion = meta.frameworkVersion
+      },
+    }))
+
+    await new Promise<void>((resolve) => {
+      build.webpack(
+        {
+          entry,
+          plugins: [plugin.webpack()],
+        },
+        () => resolve(),
+      )
+    })
+
+    expect(hostVersion).toBe(webpackVersion)
+    expect(frameworkVersion).toBe(webpackVersion)
+  }, 20_000)
+
+  it('rspack sets frameworkVersion from compiler.rspack.rspackVersion', async () => {
+    let hostVersion: string | undefined
+    let frameworkVersion: string | undefined
+    const plugin = createUnplugin((_options, meta) => ({
+      name: 'framework-version-rspack',
+      buildStart() {
+        hostVersion = (this.getNativeBuildContext?.() as any)?.compiler?.rspack?.rspackVersion
+        frameworkVersion = meta.frameworkVersion
+      },
+    }))
+
+    await new Promise<void>((resolve) => {
+      build.rspack(
+        {
+          entry,
+          plugins: [plugin.rspack()],
+        },
+        () => resolve(),
+      )
+    })
+
+    expect(hostVersion).toBe(rspackVersion)
+    expect(frameworkVersion).toBe(rspackVersion)
+  }, 20_000)
+
+  onlyBun('bun sets frameworkVersion from Bun.version', async () => {
+    let hostVersion: string | undefined
+    let frameworkVersion: string | undefined
+    const plugin = createUnplugin<undefined, false>((_options, meta) => ({
+      name: 'framework-version-bun',
+      buildStart() {
+        hostVersion = Bun.version
+        frameworkVersion = meta.frameworkVersion
+      },
+    }))
+
+    await build.bun({
+      entrypoints: [entry],
+      outdir: path.resolve(__dirname, '../filter/test-out/bun-framework-version'),
+      plugins: [plugin.bun()],
+    })
+
+    expect(hostVersion).toBe(Bun.version)
+    expect(frameworkVersion).toBe(Bun.version)
+  })
+})

--- a/test/unit-tests/rolldown/index.test.ts
+++ b/test/unit-tests/rolldown/index.test.ts
@@ -13,7 +13,10 @@ describe('getRolldownPlugin', () => {
     const factory = vi.fn()
     const plugin = getRolldownPlugin(factory)
     plugin({ foo: 'bar' })
-    expect(factory).toHaveBeenCalledWith({ foo: 'bar' }, { framework: 'rolldown' })
+    expect(factory).toHaveBeenCalledWith({ foo: 'bar' }, expect.objectContaining({
+      framework: 'rolldown',
+      versions: expect.objectContaining({ unplugin: expect.any(String) }),
+    }))
   })
 
   it('should return an array of plugins if multiple plugins are returned', () => {

--- a/test/unit-tests/unloader/index.test.ts
+++ b/test/unit-tests/unloader/index.test.ts
@@ -13,7 +13,10 @@ describe('getUnloaderPlugin', () => {
     const factory = vi.fn()
     const plugin = getUnloaderPlugin(factory)
     plugin({ foo: 'bar' })
-    expect(factory).toHaveBeenCalledWith({ foo: 'bar' }, { framework: 'unloader' })
+    expect(factory).toHaveBeenCalledWith({ foo: 'bar' }, expect.objectContaining({
+      framework: 'unloader',
+      versions: expect.objectContaining({ unplugin: expect.any(String) }),
+    }))
   })
 
   it('should return an array of plugins if multiple plugins are returned', () => {


### PR DESCRIPTION
Adds `meta.frameworkVersion` to get the version number of the host bundler for all but esbuild and Farm (which don't seem to offer the version except via `import`).

For Rollup-compatible hosts (`vite`, `rollup`, `rolldown`, `unloader`), `frameworkVersion` is set in `buildStart`, so it is not available until hook code.

Fixes #575