### PR TITLE
feat(bun)!: sanitize plugin names for Bun namespaces

### DIFF
--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -6,6 +6,12 @@ import { normalizeObjectHook } from '../utils/filter'
 import { toArray } from '../utils/general'
 import { createBuildContext, createPluginContext, guessLoader } from './utils'
 
+// Coerce plugin.name to satisfy Bun's namespace validator:
+// https://github.com/oven-sh/bun/blob/12d77d1ac561771e9fa1d0822e954273248e7f9a/src/js/builtins/BundlerPlugin.ts#L215-L217
+function toBunNamespace(name: string): string {
+  return name.replace(/[^\w$-]/g, '-')
+}
+
 export function getBunPlugin<UserOptions = Record<string, never>>(
   factory: UnpluginFactory<UserOptions>,
 ): UnpluginInstance<UserOptions>['bun'] {
@@ -102,7 +108,7 @@ export function getBunPlugin<UserOptions = Record<string, never>>(
                 if (!isAbsolute(result)) {
                   return {
                     path: result,
-                    namespace: plugin.name,
+                    namespace: toBunNamespace(plugin.name),
                   }
                 }
                 return { path: result }
@@ -112,7 +118,7 @@ export function getBunPlugin<UserOptions = Record<string, never>>(
                   return {
                     path: result.id,
                     external: result.external,
-                    namespace: plugin.name,
+                    namespace: toBunNamespace(plugin.name),
                   }
                 }
                 return {
@@ -217,7 +223,7 @@ export function getBunPlugin<UserOptions = Record<string, never>>(
         }
 
         for (const pluginName of virtualModulePlugins) {
-          build.onLoad({ filter: /.*/, namespace: pluginName }, async (args) => {
+          build.onLoad({ filter: /.*/, namespace: toBunNamespace(pluginName) }, async (args) => {
             return processLoadTransform(args.path, pluginName, args.loader)
           })
         }

--- a/test/unit-tests/bun/namespace.test.ts
+++ b/test/unit-tests/bun/namespace.test.ts
@@ -1,0 +1,126 @@
+import { createUnplugin } from 'unplugin'
+import { describe, expect, it, vi } from 'vitest'
+
+interface MockBuild {
+  build: Bun.PluginBuilder
+  resolveCallback: () => Bun.OnResolveCallback
+  loadCallbacks: Map<string, Bun.OnLoadCallback>
+}
+
+function createMockBuild(): MockBuild {
+  let resolveCallback: Bun.OnResolveCallback | undefined
+  const loadCallbacks = new Map<string, Bun.OnLoadCallback>()
+
+  const build = {
+    onResolve: vi.fn((_options, callback) => {
+      resolveCallback = callback
+    }),
+    onLoad: vi.fn((options: { namespace?: string }, callback: Bun.OnLoadCallback) => {
+      if (options.namespace) {
+        loadCallbacks.set(options.namespace, callback)
+      }
+    }),
+    onStart: vi.fn(),
+    config: { outdir: './dist' },
+  } as never as Bun.PluginBuilder
+
+  return {
+    build,
+    resolveCallback: () => {
+      if (!resolveCallback) {
+        throw new Error('onResolve was not registered')
+      }
+      return resolveCallback
+    },
+    loadCallbacks,
+  }
+}
+
+describe.skipIf(typeof Bun === 'undefined')('bun namespace sanitization', () => {
+  it('should sanitize invalid characters when resolveId returns a string', async () => {
+    const unplugin = createUnplugin(() => ({
+      name: 'unplugin:my.plugin/name',
+      resolveId: () => 'virtual-id',
+    }))
+    const { build, resolveCallback } = createMockBuild()
+
+    await unplugin.bun().setup(build)
+    const result = await resolveCallback()({
+      path: 'foo',
+      importer: 'index.js',
+      kind: 'import-statement',
+    } as Bun.OnResolveArgs)
+
+    expect(result).toEqual({
+      path: 'virtual-id',
+      namespace: 'unplugin-my-plugin-name',
+    })
+  })
+
+  it('should sanitize invalid characters when resolveId returns an object', async () => {
+    const unplugin = createUnplugin(() => ({
+      name: '@scope/plugin.name',
+      resolveId: () => ({ id: 'virtual-id', external: false }),
+    }))
+    const { build, resolveCallback } = createMockBuild()
+
+    await unplugin.bun().setup(build)
+    const result = await resolveCallback()({
+      path: 'foo',
+      importer: 'index.js',
+      kind: 'import-statement',
+    } as Bun.OnResolveArgs)
+
+    expect(result).toEqual({
+      path: 'virtual-id',
+      external: false,
+      namespace: '-scope-plugin-name',
+    })
+  })
+
+  it('should leave plugin names with only allowed characters untouched', async () => {
+    const unplugin = createUnplugin(() => ({
+      name: 'valid_plugin-name$1',
+      resolveId: () => 'virtual-id',
+    }))
+    const { build, resolveCallback } = createMockBuild()
+
+    await unplugin.bun().setup(build)
+    const result = await resolveCallback()({
+      path: 'foo',
+      importer: 'index.js',
+      kind: 'import-statement',
+    } as Bun.OnResolveArgs)
+
+    expect(result).toEqual({
+      path: 'virtual-id',
+      namespace: 'valid_plugin-name$1',
+    })
+  })
+
+  it('should invoke the original load hook when registered under a sanitized namespace', async () => {
+    const load = vi.fn(() => 'export default 1')
+    const unplugin = createUnplugin(() => ({
+      name: 'unplugin:virtual.mod',
+      resolveId: () => 'virtual-id',
+      load,
+    }))
+    const { build, loadCallbacks } = createMockBuild()
+
+    await unplugin.bun().setup(build)
+
+    expect([...loadCallbacks.keys()]).toContain('unplugin-virtual-mod')
+    expect([...loadCallbacks.keys()]).not.toContain('unplugin:virtual.mod')
+
+    const result = await loadCallbacks.get('unplugin-virtual-mod')!({
+      path: 'virtual-id',
+      loader: 'js',
+    } as Bun.OnLoadArgs)
+
+    expect(load).toHaveBeenCalledWith('virtual-id')
+    expect(result).toEqual({
+      contents: 'export default 1',
+      loader: 'js',
+    })
+  })
+})


### PR DESCRIPTION
I am volunteering and working on getting a bun plugin for TanStack/router and found this bug.

- https://github.com/TanStack/router/discussions/6871#discussioncomment-16938489
- https://github.com/unjs/unplugin/issues/598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of plugin names with invalid characters so plugins register and load correctly in Bun environments by using a sanitized namespace for non-absolute virtual modules.
* **Tests**
  * Added unit tests to verify namespace sanitization behavior and ensure plugin load hooks are invoked through the sanitized namespace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unplugin/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->