### PR TITLE
fix(bun) :: consume plugin.bun

### DIFF
--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -32,6 +32,10 @@ export function getBunPlugin<UserOptions = Record<string, never>>(
       async setup(build) {
         const context = createBuildContext(build)
 
+        for (const plugin of plugins) {
+          await plugin.bun?.setup?.(build)
+        }
+
         if (plugins.some(plugin => plugin.buildStart)) {
           build.onStart(async () => {
             for (const plugin of plugins) {

--- a/test/unit-tests/bun/nested.test.ts
+++ b/test/unit-tests/bun/nested.test.ts
@@ -131,4 +131,36 @@ describe.skipIf(typeof Bun === 'undefined')('bun nested plugin support', () => {
 
     Bun.file = originalFile
   })
+
+  it('should call plugin.bun.setup with the build before standard hooks', async () => {
+    const callOrder: string[] = []
+    const bunSetup = vi.fn((_build: Bun.PluginBuilder) => {
+      callOrder.push('plugin.bun.setup')
+    })
+
+    const unplugin = createUnplugin(() => ({
+      name: 'with-bun-setup',
+      bun: { setup: bunSetup },
+      resolveId: () => null,
+      load: () => null,
+    }))
+
+    const bunPlugin = unplugin.bun()
+    const mockBuild = {
+      onResolve: vi.fn(() => {
+        callOrder.push('onResolve')
+      }),
+      onLoad: vi.fn(() => {
+        callOrder.push('onLoad')
+      }),
+      onStart: vi.fn(),
+      config: { outdir: './dist' },
+    } as never as Bun.PluginBuilder
+
+    await bunPlugin.setup(mockBuild)
+
+    expect(bunSetup).toHaveBeenCalledTimes(1)
+    expect(bunSetup).toHaveBeenCalledWith(mockBuild)
+    expect(callOrder).toEqual(['plugin.bun.setup', 'onResolve', 'onLoad', 'onLoad'])
+  })
 })


### PR DESCRIPTION
I am volunteering and working on getting a bun plugin for TanStack/router and found this bug.

- https://github.com/TanStack/router/discussions/6871#discussioncomment-16938489
- https://github.com/unjs/unplugin/issues/602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bun plugins now support an optional setup hook that runs during plugin initialization, guaranteed to execute before other standard plugin hooks.
* **Tests**
  * Added a Bun-only unit test verifying the setup hook is invoked exactly once and occurs prior to standard hook registrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unplugin/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->