### PR TITLE
fix(bun): consume plugin.bun.setup escape hatch

### DIFF
--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -32,6 +32,13 @@ export function getBunPlugin<UserOptions = Record<string, never>>(
       async setup(build) {
         const context = createBuildContext(build)
 
+        // Allow plugins to use Bun-specific escape hatch
+        for (const plugin of plugins) {
+          if (plugin.bun?.setup) {
+            await plugin.bun.setup(build)
+          }
+        }
+
         if (plugins.some(plugin => plugin.buildStart)) {
           build.onStart(async () => {
             for (const plugin of plugins) {


### PR DESCRIPTION
## Problem

Reported in #602.

The `UnpluginOptions` type already declares `bun?: Partial<BunPlugin>`, mirroring the typed escape hatches for `esbuild`, `vite`, `webpack`, etc.

The **esbuild adapter** consumes its equivalent:
```typescript
if (plugin.esbuild?.setup) return plugin.esbuild.setup(rawBuild)
```

The **Bun adapter** never reads `plugin.bun`. Plugins that need Bun-specific behavior — mutating `build.config.define`, registering extra `onResolve`/`onLoad` hooks for bundler-specific quirks, calling `build.onStart` independently — have nowhere to put that code, even though the type allows it.

## Solution

Added consumption of `plugin.bun.setup` early in the `setup()` function, before any unplugin hooks are registered:

```typescript
// Allow plugins to use Bun-specific escape hatch
for (const plugin of plugins) {
  if (plugin.bun?.setup) {
    await plugin.bun.setup(build)
  }
}
```

This gives plugins full control over the Bun build configuration when needed, matching the behavior of the esbuild adapter.

## Testing

Verified with the reproduction case from #602:

```typescript
const plugin = createBunPlugin(() => ({
  name: 'define-injector',
  bun: {
    setup(build) {
      build.config.define = {
        ...(build.config.define ?? {}),
        'process.env.MY_FLAG': JSON.stringify('from-plugin'),
      };
    },
  },
}))();
```

Output now correctly includes `"from-plugin"` instead of leaving `process.env.MY_FLAG` untransformed.

Closes #602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Bun compatibility by enabling Bun-specific plugin initialization during the setup phase, allowing plugins to properly integrate with Bun's build environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unplugin/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->