### PR TITLE
fix: declare optional peer types

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,46 @@
     "test": "nr test:build && vitest run",
     "test:build": "jiti scripts/buildFixtures.ts"
   },
+  "peerDependencies": {
+    "@farmfe/core": "catalog:peer",
+    "@rspack/core": "catalog:peer",
+    "bun-types-no-globals": "catalog:peer",
+    "esbuild": "catalog:peer",
+    "rolldown": "catalog:peer",
+    "rollup": "catalog:peer",
+    "unloader": "catalog:peer",
+    "vite": "catalog:peer",
+    "webpack": "catalog:peer"
+  },
+  "peerDependenciesMeta": {
+    "@farmfe/core": {
+      "optional": true
+    },
+    "@rspack/core": {
+      "optional": true
+    },
+    "bun-types-no-globals": {
+      "optional": true
+    },
+    "esbuild": {
+      "optional": true
+    },
+    "rolldown": {
+      "optional": true
+    },
+    "rollup": {
+      "optional": true
+    },
+    "unloader": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@jridgewell/remapping": "catalog:prod",
     "picomatch": "catalog:prod",
@@ -61,8 +101,8 @@
     "@typescript/native-preview": "catalog:dev",
     "ansis": "catalog:dev",
     "bumpp": "catalog:dev",
-    "bun-types-no-globals": "catalog:dev",
-    "esbuild": "catalog:dev",
+    "bun-types-no-globals": "catalog:peer",
+    "esbuild": "catalog:peer",
     "eslint": "catalog:dev",
     "eslint-plugin-format": "catalog:dev",
     "jiti": "catalog:dev",
@@ -83,7 +123,7 @@
     "webpack-cli": "catalog:test"
   },
   "resolutions": {
-    "esbuild": "catalog:dev"
+    "esbuild": "catalog:peer"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm i --frozen-lockfile --ignore-scripts --offline && pnpm exec lint-staged"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,12 +30,6 @@ catalogs:
     bumpp:
       specifier: ^11.1.0
       version: 11.1.0
-    bun-types-no-globals:
-      specifier: ^1.3.11
-      version: 1.3.11
-    esbuild:
-      specifier: ^0.28.0
-      version: 0.28.0
     eslint:
       specifier: ^10.3.0
       version: 10.3.0
@@ -116,6 +110,12 @@ catalogs:
     '@rspack/core':
       specifier: ^2.0.2
       version: 2.0.2
+    bun-types-no-globals:
+      specifier: ^1.3.11
+      version: 1.3.11
+    esbuild:
+      specifier: ^0.28.0
+      version: 0.28.0
     rolldown:
       specifier: ^1.0.0
       version: 1.0.0
@@ -209,10 +209,10 @@ importers:
         specifier: catalog:dev
         version: 11.1.0
       bun-types-no-globals:
-        specifier: catalog:dev
+        specifier: catalog:peer
         version: 1.3.11
       esbuild:
-        specifier: catalog:dev
+        specifier: catalog:peer
         version: 0.28.0
       eslint:
         specifier: catalog:dev

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,8 +20,6 @@ catalogs:
     '@typescript/native-preview': 7.0.0-dev.20260508.1
     ansis: ^4.3.1
     bumpp: ^11.1.0
-    bun-types-no-globals: ^1.3.11
-    esbuild: ^0.28.1
     eslint: ^10.5.0
     eslint-plugin-format: ^2.0.1
     jiti: ^2.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,8 +20,6 @@ catalogs:
     '@typescript/native-preview': 7.0.0-dev.20260508.1
     ansis: ^4.2.0
     bumpp: ^11.1.0
-    bun-types-no-globals: ^1.3.11
-    esbuild: ^0.28.0
     eslint: ^10.3.0
     eslint-plugin-format: ^2.0.1
     jiti: ^2.7.0
@@ -52,6 +50,8 @@ catalogs:
   peer:
     '@farmfe/core': ^1.7.11
     '@rspack/core': ^2.0.2
+    bun-types-no-globals: ^1.3.11
+    esbuild: ^0.28.0
     rolldown: ^1.0.0
     rollup: ^4.60.3
     unloader: ^0.9.0

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   },
   unused: {
     level: 'error',
+    ignore: ['bun-types-no-globals'],
   },
   exports: true,
   publint: 'ci-only',


### PR DESCRIPTION
### Summary

Adds the bundler/runtime packages referenced by `unplugin`'s generated declaration files as optional peer dependencies, including the existing Bun type package.

This lets strict package managers surface the optional type packages instead of leaving consumers with unresolved imports from `dist/index.d.mts`.

Fixes #605

### Test plan

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package dependency declarations to treat several build-tool libraries as optional peer dependencies.
  * Adjusted development tooling sourcing for type support and bundling to align with the updated optional peer dependency strategy.
  * Reorganized the workspace dependency catalog so optional vs. required relationships are reflected more accurately.
  * Updated the type-check configuration to ignore an unused warning for one type-support package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->