### PR TITLE
chore: add npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/unjs/unplugin.git"
   },
+  "bugs": {
+    "url": "https://github.com/unjs/unplugin/issues"
+  },
   "sideEffects": false,
   "exports": {
     ".": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

- add the package `bugs.url` metadata pointing to the public GitHub issue tracker
- leave runtime code, dependencies, version, homepage, and repository metadata unchanged

## Validation

- `node -e "const p=require('./package.json'); if (p.bugs?.url !== 'https://github.com/unjs/unplugin/issues') throw new Error('bad bugs metadata'); if (p.homepage !== 'https://unplugin.unjs.io') throw new Error('homepage changed'); console.log('package metadata ok')"`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include bug reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->