### PR TITLE
fix(webpack): forward async load hook errors to the loader callback

### DIFF
--- a/src/webpack/loaders/load.ts
+++ b/src/webpack/loaders/load.ts
@@ -17,22 +17,32 @@ export default async function load(this: LoaderContext<any>, source: string, map
 
   const context = createContext(this)
   const { handler } = normalizeObjectHook('load', plugin.load)
-  const res = await handler.call(
-    Object.assign({}, createBuildContext({
-      addWatchFile: (file) => {
-        this.addDependency(file)
-      },
-      getWatchFiles: () => {
-        return this.getDependencies()
-      },
-    }, this._compiler!, this._compilation, this), context),
-    normalizeAbsolutePath(id),
-  )
+  try {
+    const res = await handler.call(
+      Object.assign({}, createBuildContext({
+        addWatchFile: (file) => {
+          this.addDependency(file)
+        },
+        getWatchFiles: () => {
+          return this.getDependencies()
+        },
+      }, this._compiler!, this._compilation, this), context),
+      normalizeAbsolutePath(id),
+    )
 
-  if (res == null)
-    callback(null, source, map)
-  else if (typeof res !== 'string')
-    callback(null, res.code, res.map ?? map)
-  else
-    callback(null, res, map)
+    if (res == null)
+      callback(null, source, map)
+    else if (typeof res !== 'string')
+      callback(null, res.code, res.map ?? map)
+    else
+      callback(null, res, map)
+  }
+  catch (error) {
+    if (error instanceof Error) {
+      callback(error)
+    }
+    else {
+      callback(new Error(String(error)))
+    }
+  }
 }

--- a/test/unit-tests/webpack/loaders/load.test.ts
+++ b/test/unit-tests/webpack/loaders/load.test.ts
@@ -62,4 +62,17 @@ describe('load function', () => {
 
     expect(mockCallback).toHaveBeenCalledWith(null, transformedCode, map)
   })
+
+  it('should call callback with the error if the handler throws', async () => {
+    const source = 'source code'
+    const map = 'source map'
+    const error = new Error('Handler error')
+    const pluginLoadHandler = vi.fn().mockRejectedValue(error)
+    mockLoaderContext.query.plugin.load = pluginLoadHandler
+
+    await load.call(mockLoaderContext as any, source, map)
+
+    expect(pluginLoadHandler).toHaveBeenCalled()
+    expect(mockCallback).toHaveBeenCalledWith(error)
+  })
 })


### PR DESCRIPTION
The webpack `load` loader awaits the user `load` hook but never catches a rejection. When a `load` hook throws, the error escapes the loader function instead of being passed to webpack's loader `callback`. Since the loader calls `this.async()`, webpack's loader runner doesn't await the returned promise, so the throw surfaces as an unhandled promise rejection rather than a normal build error.

The sibling loaders already forward the error to `callback`:

- `src/webpack/loaders/transform.ts` wraps the handler in try/catch and calls `callback(error)`.
- `src/rspack/loaders/load.ts` got the same handling in #536.

This wraps the webpack `load` loader the same way, and adds a unit test that mirrors the existing `transform` loader error test. Reverting only the source change makes the new test fail (the rejection propagates out of `load` instead of reaching the callback); with the change the webpack and rspack loader test files pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loader error handling so failed async handlers now correctly report errors through the callback.
  * Non-standard thrown values are converted into standard errors before being returned, making failures more consistent.
  * Existing successful result handling remains unchanged for null, string, and object responses.

* **Tests**
  * Added coverage for rejected or thrown loader handlers to verify errors are passed to the callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->