### PR TITLE
fix(esbuild): handle browser:false stubs in getContents

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -119,7 +119,18 @@ export function getEsbuildPlugin<UserOptions = Record<string, never>>(
                   // caution: 'utf8' assumes the input file is not in binary.
                   // if you want your plugin handle binary files, make sure to
                   // `plugin.load()` them first.
-                  return (fsContentsCache = await fs.promises.readFile(args.path, 'utf8'))
+                  try {
+                    return (fsContentsCache = await fs.promises.readFile(args.path, 'utf8'))
+                  }
+                  catch (error) {
+                    // esbuild resolves `package.json#browser` entries mapped to `false`
+                    // to a path that does not exist on disk (the module is meant to be
+                    // stubbed out as empty). Treat a missing file the same way esbuild
+                    // itself treats these stubs instead of throwing.
+                    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT')
+                      return (fsContentsCache = '')
+                    throw error
+                  }
                 },
               }
 

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -100,6 +100,7 @@ export function getEsbuildPlugin<UserOptions = Record<string, never>>(
           }
 
           let fsContentsCache: string | undefined
+          let fsContentsCached = false
 
           for (const { options, onTransformCb } of loaders) {
             if (!checkFilter(options))
@@ -113,22 +114,27 @@ export function getEsbuildPlugin<UserOptions = Record<string, never>>(
                   if (result?.contents)
                     return result.contents as string
 
-                  if (fsContentsCache)
-                    return fsContentsCache
+                  if (fsContentsCached)
+                    return fsContentsCache as string
 
                   // caution: 'utf8' assumes the input file is not in binary.
                   // if you want your plugin handle binary files, make sure to
                   // `plugin.load()` them first.
                   try {
-                    return (fsContentsCache = await fs.promises.readFile(args.path, 'utf8'))
+                    fsContentsCache = await fs.promises.readFile(args.path, 'utf8')
+                    fsContentsCached = true
+                    return fsContentsCache
                   }
                   catch (error) {
                     // esbuild resolves `package.json#browser` entries mapped to `false`
                     // to a path that does not exist on disk (the module is meant to be
                     // stubbed out as empty). Treat a missing file the same way esbuild
                     // itself treats these stubs instead of throwing.
-                    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT')
-                      return (fsContentsCache = '')
+                    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+                      fsContentsCache = ''
+                      fsContentsCached = true
+                      return fsContentsCache
+                    }
                     throw error
                   }
                 },

--- a/test/unit-tests/esbuild/fixtures/browser-false-stub/entry.js
+++ b/test/unit-tests/esbuild/fixtures/browser-false-stub/entry.js
@@ -1,0 +1,1 @@
+require('./pkg')

--- a/test/unit-tests/esbuild/fixtures/browser-false-stub/pkg/lib/index.js
+++ b/test/unit-tests/esbuild/fixtures/browser-false-stub/pkg/lib/index.js
@@ -1,0 +1,3 @@
+require('./terminal-highlight')
+
+module.exports = 'pkg-index'

--- a/test/unit-tests/esbuild/fixtures/browser-false-stub/pkg/package.json
+++ b/test/unit-tests/esbuild/fixtures/browser-false-stub/pkg/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pkg",
+  "version": "1.0.0",
+  "main": "./lib/index.js",
+  "browser": {
+    "./lib/terminal-highlight": false
+  }
+}

--- a/test/unit-tests/esbuild/index.test.ts
+++ b/test/unit-tests/esbuild/index.test.ts
@@ -1,0 +1,29 @@
+import { resolve } from 'node:path'
+import { build } from 'esbuild'
+import { describe, expect, it } from 'vitest'
+import { createUnplugin } from '../../../src/index'
+
+const fixtureDir = resolve(__dirname, 'fixtures/browser-false-stub')
+
+describe('esbuild getContents with browser:false stubbed module', () => {
+  it('does not throw ENOENT when transform.getContents() is called for a file switched off via package.json/browser', async () => {
+    const plugin = createUnplugin(() => ({
+      name: 'passthru',
+      transform: {
+        filter: { id: /\.[cm]?js$/ },
+        async handler(code) {
+          return { code }
+        },
+      },
+    }))
+
+    await expect(build({
+      absWorkingDir: fixtureDir,
+      entryPoints: ['./entry.js'],
+      bundle: true,
+      platform: 'browser',
+      write: false,
+      plugins: [plugin.esbuild()],
+    })).resolves.toBeDefined()
+  })
+})

--- a/test/unit-tests/esbuild/index.test.ts
+++ b/test/unit-tests/esbuild/index.test.ts
@@ -1,3 +1,4 @@
+import type { Plugin } from 'esbuild'
 import fs from 'node:fs'
 import { resolve } from 'node:path'
 import { build } from 'esbuild'
@@ -5,6 +6,17 @@ import { describe, expect, it, vi } from 'vitest'
 import { createUnplugin } from '../../../src/index'
 
 const fixtureDir = resolve(__dirname, 'fixtures/browser-false-stub')
+
+function buildFixture(esbuildPlugin: Plugin) {
+  return build({
+    absWorkingDir: fixtureDir,
+    entryPoints: ['./entry.js'],
+    bundle: true,
+    platform: 'browser',
+    write: false,
+    plugins: [esbuildPlugin],
+  })
+}
 
 describe('esbuild getContents with browser:false stubbed module', () => {
   it('does not throw ENOENT when transform.getContents() is called for a file switched off via package.json/browser', async () => {
@@ -18,54 +30,43 @@ describe('esbuild getContents with browser:false stubbed module', () => {
       },
     }))
 
-    await expect(build({
-      absWorkingDir: fixtureDir,
-      entryPoints: ['./entry.js'],
-      bundle: true,
-      platform: 'browser',
-      write: false,
-      plugins: [plugin.esbuild()],
-    })).resolves.toBeDefined()
+    await expect(buildFixture(plugin.esbuild())).resolves.toBeDefined()
   })
 
   it('caches the empty contents from an ENOENT stub so a second transform does not re-read the file', async () => {
     const readFileSpy = vi.spyOn(fs.promises, 'readFile')
 
-    // Two transform hooks on the same plugin instance both call getContents()
-    // for the same onLoad args, exercising the shared fsContentsCache.
-    const plugin = createUnplugin(() => [
-      {
-        name: 'passthru-1',
-        transform: {
-          filter: { id: /\.[cm]?js$/ },
-          async handler(code) {
-            return { code }
+    try {
+      // Two transform hooks on the same plugin instance both call getContents()
+      // for the same onLoad args, exercising the shared fsContentsCache.
+      const plugin = createUnplugin(() => [
+        {
+          name: 'passthru-1',
+          transform: {
+            filter: { id: /\.[cm]?js$/ },
+            async handler(code) {
+              return { code }
+            },
           },
         },
-      },
-      {
-        name: 'passthru-2',
-        transform: {
-          filter: { id: /\.[cm]?js$/ },
-          async handler(code) {
-            return { code }
+        {
+          name: 'passthru-2',
+          transform: {
+            filter: { id: /\.[cm]?js$/ },
+            async handler(code) {
+              return { code }
+            },
           },
         },
-      },
-    ])
+      ])
 
-    await expect(build({
-      absWorkingDir: fixtureDir,
-      entryPoints: ['./entry.js'],
-      bundle: true,
-      platform: 'browser',
-      write: false,
-      plugins: [plugin.esbuild()],
-    })).resolves.toBeDefined()
+      await expect(buildFixture(plugin.esbuild())).resolves.toBeDefined()
 
-    const stubReads = readFileSpy.mock.calls.filter(([path]) => String(path).includes('terminal-highlight'))
-    expect(stubReads).toHaveLength(1)
-
-    readFileSpy.mockRestore()
+      const stubReads = readFileSpy.mock.calls.filter(([path]) => String(path).includes('terminal-highlight'))
+      expect(stubReads).toHaveLength(1)
+    }
+    finally {
+      readFileSpy.mockRestore()
+    }
   })
 })

--- a/test/unit-tests/esbuild/index.test.ts
+++ b/test/unit-tests/esbuild/index.test.ts
@@ -1,6 +1,7 @@
+import fs from 'node:fs'
 import { resolve } from 'node:path'
 import { build } from 'esbuild'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createUnplugin } from '../../../src/index'
 
 const fixtureDir = resolve(__dirname, 'fixtures/browser-false-stub')
@@ -25,5 +26,46 @@ describe('esbuild getContents with browser:false stubbed module', () => {
       write: false,
       plugins: [plugin.esbuild()],
     })).resolves.toBeDefined()
+  })
+
+  it('caches the empty contents from an ENOENT stub so a second transform does not re-read the file', async () => {
+    const readFileSpy = vi.spyOn(fs.promises, 'readFile')
+
+    // Two transform hooks on the same plugin instance both call getContents()
+    // for the same onLoad args, exercising the shared fsContentsCache.
+    const plugin = createUnplugin(() => [
+      {
+        name: 'passthru-1',
+        transform: {
+          filter: { id: /\.[cm]?js$/ },
+          async handler(code) {
+            return { code }
+          },
+        },
+      },
+      {
+        name: 'passthru-2',
+        transform: {
+          filter: { id: /\.[cm]?js$/ },
+          async handler(code) {
+            return { code }
+          },
+        },
+      },
+    ])
+
+    await expect(build({
+      absWorkingDir: fixtureDir,
+      entryPoints: ['./entry.js'],
+      bundle: true,
+      platform: 'browser',
+      write: false,
+      plugins: [plugin.esbuild()],
+    })).resolves.toBeDefined()
+
+    const stubReads = readFileSpy.mock.calls.filter(([path]) => String(path).includes('terminal-highlight'))
+    expect(stubReads).toHaveLength(1)
+
+    readFileSpy.mockRestore()
   })
 })


### PR DESCRIPTION
The esbuild adapter's `getContents()` reads `args.path` with `fs.readFile` unconditionally. When esbuild resolves a `package.json#browser` entry mapped to `false` (a common way to stub a module out for the browser), unplugin gets a path that does not exist on disk and `readFile` throws an uncaught `ENOENT`, crashing the build (#546).

This wraps the read in a try/catch: on `ENOENT` it returns empty contents (matching how esbuild itself treats these stubs) and re-throws any other error unchanged.

Added an in-process esbuild build test with a fixture whose `browser` field maps a module to `false`. It reproduces the ENOENT without the fix and passes with it.

Closes #546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser builds so modules disabled via `package.json` `browser` mappings no longer fail when source files are absent; missing contents are treated as empty.
  * Fixed content caching to correctly reuse empty results across multiple transform operations, avoiding unnecessary filesystem reads and potential `ENOENT` errors.
* **Tests**
  * Added/updated esbuild/Vitest fixtures and tests for `browser:false` stubs, including coverage for graceful resolution and cached empty-content behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->