### PR TITLE
fix: preserve transform sourcemaps for webpack and rspack

### DIFF
--- a/src/rspack/loaders/transform.ts
+++ b/src/rspack/loaders/transform.ts
@@ -30,11 +30,21 @@ export default async function transform(
       id,
     )
 
-    if (res == null)
+    if (res == null) {
       callback(null, source, map)
-    else if (typeof res !== 'string')
-      callback(null, res.code, map == null ? map : (res.map || map))
-    else callback(null, res, map)
+    }
+    else if (typeof res !== 'string') {
+      const resultMap = map && res.map
+        ? (await import('@jridgewell/remapping')).default(
+            [res.map, map],
+            () => null,
+          )
+        : (res.map ?? map)
+      callback(null, res.code, resultMap)
+    }
+    else {
+      callback(null, res, map)
+    }
   }
   catch (error) {
     if (error instanceof Error) {

--- a/src/webpack/loaders/transform.ts
+++ b/src/webpack/loaders/transform.ts
@@ -29,12 +29,21 @@ export default async function transform(this: LoaderContext<any>, source: string
       this.resource,
     )
 
-    if (res == null)
+    if (res == null) {
       callback(null, source, map)
-    else if (typeof res !== 'string')
-      callback(null, res.code, map == null ? map : (res.map || map))
-    else
+    }
+    else if (typeof res !== 'string') {
+      const resultMap = map && res.map
+        ? (await import('@jridgewell/remapping')).default(
+            [res.map, map],
+            () => null,
+          )
+        : (res.map ?? map)
+      callback(null, res.code, resultMap)
+    }
+    else {
       callback(null, res, map)
+    }
   }
   catch (error) {
     if (error instanceof Error) {

--- a/test/unit-tests/rspack/loaders/transform.test.ts
+++ b/test/unit-tests/rspack/loaders/transform.test.ts
@@ -3,6 +3,21 @@ import { assert, describe, expect, it, vi } from 'vitest'
 import transform from '../../../../src/rspack/loaders/transform'
 
 describe('transform', () => {
+  const originalSourceMap = {
+    version: 3,
+    names: [],
+    sources: ['original.ts'],
+    sourcesContent: ['original source'],
+    mappings: 'AACA',
+  }
+  const transformedSourceMap = {
+    version: 3,
+    names: [],
+    sources: ['intermediate.js'],
+    sourcesContent: ['intermediate source'],
+    mappings: ';AAAA',
+  }
+
   it('should call callback with source and map if plugin.transform is not defined', async () => {
     const mockCallback = vi.fn()
     const mockLoaderContext = {
@@ -66,11 +81,74 @@ describe('transform', () => {
     expect(mockCallback.mock.calls[0][0].message).toBe('Handler error')
   })
 
+  it('should return the transformed source map without an input source map', async () => {
+    const mockCallback = vi.fn()
+    const mockLoaderContext = {
+      async: () => mockCallback,
+      query: {
+        plugin: {
+          transform: {
+            handler: vi.fn().mockResolvedValue({
+              code: 'transformed source',
+              map: transformedSourceMap,
+            }),
+            filter: vi.fn().mockReturnValue(true),
+          },
+        },
+      },
+      resource: 'test resource',
+      _compiler: {},
+      _compilation: {},
+    } as any
+
+    await transform.call(mockLoaderContext, 'test source', null)
+
+    expect(mockCallback).toHaveBeenCalledWith(
+      null,
+      'transformed source',
+      transformedSourceMap,
+    )
+  })
+
+  it('should combine input and transformed source maps', async () => {
+    const mockCallback = vi.fn()
+    const mockLoaderContext = {
+      async: () => mockCallback,
+      query: {
+        plugin: {
+          transform: {
+            handler: vi.fn().mockResolvedValue({
+              code: 'transformed source',
+              map: transformedSourceMap,
+            }),
+            filter: vi.fn().mockReturnValue(true),
+          },
+        },
+      },
+      resource: 'test resource',
+      _compiler: {},
+      _compilation: {},
+    } as any
+
+    await transform.call(mockLoaderContext, 'test source', originalSourceMap)
+
+    expect(mockCallback).toHaveBeenCalledWith(
+      null,
+      'transformed source',
+      expect.objectContaining({
+        version: 3,
+        sources: ['original.ts'],
+        sourcesContent: ['original source'],
+        mappings: ';AACA',
+      }),
+    )
+  })
+
   it('should include input source map on native build context', async () => {
     const source = 'source code'
-    const map = 'source map'
+    const map = originalSourceMap
     const transformedCode = 'transformed code'
-    const transformedMap = 'transformed map'
+    const transformedMap = transformedSourceMap
 
     let handlerSource: string | undefined
     let handlerId: string | undefined
@@ -108,6 +186,14 @@ describe('transform', () => {
     assert(handlerNativeBuildContext?.framework === 'rspack')
     expect(handlerNativeBuildContext?.inputSourceMap).toBe(map)
 
-    expect(mockCallback).toHaveBeenCalledWith(null, transformedCode, transformedMap)
+    expect(mockCallback).toHaveBeenCalledWith(
+      null,
+      transformedCode,
+      expect.objectContaining({
+        sources: ['original.ts'],
+        sourcesContent: ['original source'],
+        mappings: ';AACA',
+      }),
+    )
   })
 })

--- a/test/unit-tests/webpack/loaders/transform.test.ts
+++ b/test/unit-tests/webpack/loaders/transform.test.ts
@@ -3,6 +3,20 @@ import { assert, describe, expect, it, vi } from 'vitest'
 import transform from '../../../../src/webpack/loaders/transform'
 
 describe('transform loader', () => {
+  const originalSourceMap = {
+    version: 3,
+    names: [],
+    sources: ['original.ts'],
+    sourcesContent: ['original source'],
+    mappings: 'AACA',
+  }
+  const transformedSourceMap = {
+    version: 3,
+    names: [],
+    sources: ['intermediate.js'],
+    sourcesContent: ['intermediate source'],
+    mappings: ';AAAA',
+  }
   const mockCallback = vi.fn()
   const mockLoaderContext = {
     async: () => mockCallback,
@@ -66,7 +80,7 @@ describe('transform loader', () => {
 
   it('should call handler and return transformed code and map if handler returns an object', async () => {
     const source = 'source code'
-    const map = 'source map'
+    const map = null
     const transformedResult = { code: 'transformed code', map: 'transformed map' }
 
     const handlerMock = vi.fn().mockResolvedValue(transformedResult)
@@ -83,6 +97,65 @@ describe('transform loader', () => {
 
     expect(handlerMock).toHaveBeenCalled()
     expect(mockCallback).toHaveBeenCalledWith(null, transformedResult.code, transformedResult.map)
+  })
+
+  it('should return the transformed source map without an input source map', async () => {
+    const source = 'source code'
+    const transformedCode = 'transformed code'
+
+    mockLoaderContext.query = {
+      plugin: {
+        transform: {
+          handler: vi.fn().mockResolvedValue({
+            code: transformedCode,
+            map: transformedSourceMap,
+          }),
+          filter: vi.fn().mockReturnValue(true),
+        },
+      },
+    }
+
+    await transform.call(mockLoaderContext as any, source, null)
+
+    expect(mockCallback).toHaveBeenCalledWith(
+      null,
+      transformedCode,
+      transformedSourceMap,
+    )
+  })
+
+  it('should combine input and transformed source maps', async () => {
+    const source = 'source code'
+    const transformedCode = 'transformed code'
+
+    mockLoaderContext.query = {
+      plugin: {
+        transform: {
+          handler: vi.fn().mockResolvedValue({
+            code: transformedCode,
+            map: transformedSourceMap,
+          }),
+          filter: vi.fn().mockReturnValue(true),
+        },
+      },
+    }
+
+    await transform.call(
+      mockLoaderContext as any,
+      source,
+      originalSourceMap,
+    )
+
+    expect(mockCallback).toHaveBeenCalledWith(
+      null,
+      transformedCode,
+      expect.objectContaining({
+        version: 3,
+        sources: ['original.ts'],
+        sourcesContent: ['original source'],
+        mappings: ';AACA',
+      }),
+    )
   })
 
   it('should handle errors thrown by the handler', async () => {
@@ -108,9 +181,9 @@ describe('transform loader', () => {
 
   it('should include input source map on native build context', async () => {
     const source = 'source code'
-    const map = 'source map'
+    const map = originalSourceMap
     const transformedCode = 'transformed code'
-    const transformedMap = 'transformed map'
+    const transformedMap = transformedSourceMap
 
     let handlerSource: string | undefined
     let handlerId: string | undefined
@@ -139,6 +212,14 @@ describe('transform loader', () => {
     assert(handlerNativeBuildContext?.framework === 'webpack')
     expect(handlerNativeBuildContext?.inputSourceMap).toBe(map)
 
-    expect(mockCallback).toHaveBeenCalledWith(null, transformedCode, transformedMap)
+    expect(mockCallback).toHaveBeenCalledWith(
+      null,
+      transformedCode,
+      expect.objectContaining({
+        sources: ['original.ts'],
+        sourcesContent: ['original source'],
+        mappings: ';AACA',
+      }),
+    )
   })
 })


### PR DESCRIPTION
## Summary

- preserve transform sourcemaps when no input sourcemap is provided to the loader
- combine transformed and upstream sourcemaps for Webpack and Rspack instead of dropping either mapping layer
- add regression coverage for sourcemap passthrough and composition in both adapters

## Tests

- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-map handling for Webpack and Rspack transformations.
  * Preserved transformed or incoming source maps when only one is available.
  * Correctly combines source maps when both transformed and incoming maps exist.
* **Tests**
  * Added coverage for transformed source maps and combined source-map output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->